### PR TITLE
amd64: dts: match N366 plastics sector numbering

### DIFF
--- a/arch/arm64/boot/dts/marvell/armada-8040-n366.dts
+++ b/arch/arm64/boot/dts/marvell/armada-8040-n366.dts
@@ -32,13 +32,13 @@
 	/* Declare wigig devices for the gen_node_info_file.sh script */
 	wigig_devices {
 		wigig0: wigig@0 {
-			pci-bus = "0003:01:00.0";
+			pci-bus = "0000:01:00.0";
 		};
 		wigig1: wigig@1 {
 			pci-bus = "0002:01:00.0";
 		};
 		wigig2: wigig@2 {
-			pci-bus = "0000:01:00.0";
+			pci-bus = "0003:01:00.0";
 		};
 		wigig3: wigig@3 {
 			pci-bus = "0001:01:00.0";

--- a/arch/arm64/boot/dts/marvell/armada-8040-n366.dts
+++ b/arch/arm64/boot/dts/marvell/armada-8040-n366.dts
@@ -32,16 +32,16 @@
 	/* Declare wigig devices for the gen_node_info_file.sh script */
 	wigig_devices {
 		wigig0: wigig@0 {
-			pci-bus = "0000:01:00.0";
+			pci-bus = "0003:01:00.0";
 		};
 		wigig1: wigig@1 {
-			pci-bus = "0001:01:00.0";
-		};
-		wigig2: wigig@2 {
 			pci-bus = "0002:01:00.0";
 		};
+		wigig2: wigig@2 {
+			pci-bus = "0000:01:00.0";
+		};
 		wigig3: wigig@3 {
-			pci-bus = "0003:01:00.0";
+			pci-bus = "0001:01:00.0";
 		};
 	};
 


### PR DESCRIPTION
align the numbering of the sectors on the plastic casing of N366 to the PCI ports numbers and the SW sectors' numbers.
note that the numbers on the casing start at 1 while the PCI ports and SW numbers start at 0.