### PR TITLE
Call devm_thermal_add_hwmon_sysfs in armada_thermal.c

### DIFF
--- a/drivers/thermal/armada_thermal.c
+++ b/drivers/thermal/armada_thermal.c
@@ -20,6 +20,7 @@
 #include <linux/interrupt.h>
 
 #include "thermal_core.h"
+#include "thermal_hwmon.h"
 
 /* Thermal Manager Control and Status Register */
 #define PMU_TDC0_SW_RST_MASK		(0x1 << 1)
@@ -939,6 +940,10 @@ static int armada_thermal_probe(struct platform_device *pdev)
 		 */
 		if (irq > 0 && !priv->overheat_sensor)
 			armada_configure_overheat_int(priv, tz, sensor->id);
+
+		if (devm_thermal_add_hwmon_sysfs(tz))
+			dev_warn(&pdev->dev,
+				"Failed to add hwmon sysfs attributes\n");
 	}
 
 	/* Just complain if no overheat interrupt was set up */


### PR DESCRIPTION
 * Fixes DEV-1805 hwmon devices not created