### PR TITLE
DEV-4312: cTU boot when PCIe link down

### DIFF
--- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
+++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
@@ -233,7 +233,7 @@
 			interrupts = <GIC_SPI 208 IRQ_TYPE_LEVEL_HIGH>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			gpio-ranges = <&tlmm 0 80>;
+			gpio-ranges = <&tlmm 0 0 80>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
 

--- a/drivers/pci/controller/dwc/pcie-qcom.c
+++ b/drivers/pci/controller/dwc/pcie-qcom.c
@@ -246,7 +246,9 @@ static int qcom_pcie_establish_link(struct qcom_pcie *pcie)
 	if (pcie->ops->ltssm_enable)
 		pcie->ops->ltssm_enable(pcie);
 
-	return dw_pcie_wait_for_link(pci);
+	dw_pcie_wait_for_link(pci);
+
+	return 0;
 }
 
 static void qcom_pcie_2_1_0_ltssm_enable(struct qcom_pcie *pcie)


### PR DESCRIPTION
The new cTU board with commercial grade SoC fails to boot. The log messages show that PCIe link fails to come up. This appears to trigger other bugs that cause the kernel to hang half way through boot.

Backport two fixes from newer kernels to make the kernel complete boot without hanging even when PCIe link does not come up.