### PR TITLE
net: mvpp2: increase delay after .mac_prepare

### DIFF
--- a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
+++ b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
@@ -6280,7 +6280,7 @@ static int mvpp2_mac_prepare(struct phylink_config *config, unsigned int mode,
 	if (ret == 0)
 		phylink_set_pcs(port->phylink, &port->phylink_pcs);
 
-	mdelay(10);
+	mdelay(100);
 
 	return ret;
 }


### PR DESCRIPTION
The delay introduced in a previous commit is not enough for some N366
hardware. Increase delay to 100ms to solve the problem.