### PR TITLE
Compile dts with symbols

### DIFF
--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -297,6 +297,9 @@ DTC_FLAGS += -Wnode_name_chars_strict \
 	-Winterrupt_provider
 endif
 
+# Compile dts with symbols to support overlays
+DTC_FLAGS += -@
+
 DTC_FLAGS += $(DTC_FLAGS_$(basetarget))
 
 # Generate an assembly file to wrap the output of the device tree compiler


### PR DESCRIPTION
We need symbols in order to allow overlays to reference existing nodes