### PR TITLE
DEV-5601: never poweroff the machine

### DIFF
--- a/drivers/firmware/psci/psci.c
+++ b/drivers/firmware/psci/psci.c
@@ -442,7 +442,8 @@ static void __init psci_0_2_set_functions(void)
 
 	arm_pm_restart = psci_sys_reset;
 
-	pm_power_off = psci_sys_poweroff;
+	if (!pm_power_off)
+		pm_power_off = psci_sys_poweroff;
 }
 
 /*

--- a/drivers/firmware/psci/psci.c
+++ b/drivers/firmware/psci/psci.c
@@ -442,7 +442,7 @@ static void __init psci_0_2_set_functions(void)
 
 	arm_pm_restart = psci_sys_reset;
 
-	if (!pm_power_off)
+	if (pm_power_off != NULL)
 		pm_power_off = psci_sys_poweroff;
 }
 

--- a/drivers/power/reset/restart-poweroff.c
+++ b/drivers/power/reset/restart-poweroff.c
@@ -22,12 +22,15 @@ static void restart_poweroff_do_poweroff(void)
 
 static int restart_poweroff_probe(struct platform_device *pdev)
 {
+	/* XXX: ignore any previous settings - we want to reboot instead of poweroff */
+#if 0
 	/* If a pm_power_off function has already been added, leave it alone */
 	if (pm_power_off != NULL) {
 		dev_err(&pdev->dev,
 			"pm_power_off function already registered");
 		return -EBUSY;
 	}
+#endif
 
 	pm_power_off = &restart_poweroff_do_poweroff;
 	return 0;


### PR DESCRIPTION
We never want to poweroff the machine. So make sure that always restart-poweroff's pm_power_off will be called. 