### PR TITLE
DEV-6442: Add initialization order to the falcon phy and modems

### DIFF
--- a/drivers/clk/mvebu/cp110-system-controller.c
+++ b/drivers/clk/mvebu/cp110-system-controller.c
@@ -130,7 +130,16 @@ static int cp110_gate_enable(struct clk_hw *hw)
 
 static void cp110_gate_disable(struct clk_hw *hw)
 {
-	struct cp110_gate_clk *gate = to_cp110_gate_clk(hw);
+	struct cp110_gate_clk *gate = to_cp110_gate_clk(hw);  
+
+// ignore disabling those specific clock as a temporarily solution to a problem: 
+// the pcie(s) try to enable those clocks in their init but this causes a kernel stuck, 
+// and even pcie reset doesn't help. a proper solution will be implemented in 
+// DEV-6467: Improve DEV-6442-Add initialization order to the falcon phy and modems
+	if ((gate->bit_idx == CP110_GATE_PCIE_X1_0) ||
+		(gate->bit_idx == CP110_GATE_PCIE_X4)) {
+			return;
+		}
 
 	regmap_update_bits(gate->regmap, CP110_PM_CLOCK_GATING_REG,
 			   BIT(gate->bit_idx), 0);

--- a/drivers/ptp/ptp_clockmatrix.h
+++ b/drivers/ptp/ptp_clockmatrix.h
@@ -118,6 +118,7 @@ struct idtcm {
 	u8			calculate_overhead_flag;
 	s64			tod_write_overhead_ns;
 	ktime_t			start_time;
+	struct clk_hw *clock_hw;
 };
 
 struct idtcm_fwrc {


### PR DESCRIPTION
The way to receive this order is to define the dpll as hw clock (in falcon.dts, and clock registration in ptp_clockmatrix.c dpll driver init function), and rely on the dts clock dependencies (declare both phy and pcie as depended on this clock).

This works well for the phy but the pcies (modem) need to enable two clocks ( CP110_GATE_PCIE_X1_0 & CP110_GATE_PCIE_X4) that were formerly disabled by the kernel, and that causes kernel stuck. (in the former version, the pcie driver init was earlier and before the kernel disabled those clocks). Also reset pcie through gpio after the disable+enable didn't help. So "DEV-6467: Improve DEV-6442-Add initialization order to the falcon phy and modems" was opened to further investigate and handle this problem, and meanwhile a patch was entered in cp110-system-controller.c:cp110_gate_disable to never disable those two clocks.