### PR TITLE
DEV-7348: fix 1588TC time error spikes in marvell10g_ptp caused by the PHY's egress drop FIFO

### DIFF
--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -27,6 +27,7 @@ enum {
 
 	/* Vendor2 MMD registers */
 	MV_V2_SLC_CFG_GEN		= 0x8000,
+	MV_V2_SLC_CFG_GEN_EGR_SF_EN	= BIT(2),
 	MV_V2_SLC_CFG_GEN_WMC_ADD_CRC	= BIT(8),
 	MV_V2_SLC_CFG_GEN_SMC_ADD_CRC	= BIT(9),
 	MV_V2_SLC_CFG_GEN_WMC_STRIP_CRC	= BIT(10),
@@ -144,6 +145,8 @@ static int mv3310_write_ptp_lut_reg(struct phy_device *phydev, u32 regnum,
 				    u32 regval);
 static int mv3310_set_ptp_reg_bits(struct phy_device *phydev, u32 regnum,
 				   u32 bits);
+static int mv3310_clear_ptp_reg_bits(struct phy_device *phydev, u32 regnum,
+				     u32 bits);
 
 /* TOD functions */
 static int mv3310_adjfine(struct ptp_clock_info *ptp, long scaled_ppm);
@@ -267,6 +270,11 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv)
 					      MV_V2_SLC_CFG_GEN_SMC_ADD_CRC |
 					      MV_V2_SLC_CFG_GEN_WMC_STRIP_CRC |
 					      MV_V2_SLC_CFG_GEN_SMC_STRIP_CRC);
+	/* Disable store-and-forward mode for egress drop FIFO. Without this
+	   setting there are time error spikes of up to 1200ns when performing
+	   1588TC accuracy measurements. */
+	ret |= mv3310_clear_ptp_reg_bits(phydev, MV_V2_SLC_CFG_GEN,
+					 MV_V2_SLC_CFG_GEN_EGR_SF_EN);
 unlock_out:
 	mutex_unlock(&priv->lock);
 	return ret;
@@ -398,8 +406,9 @@ static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
 	if (ret < 0)
 		return ret;
 	if (ret != regnum) {
-		pr_err("Indirect read address mismatch: %04x != %04x\n", ret,
-		       regnum);
+		dev_err(&phydev->mdio.dev,
+			"Indirect read address mismatch: %04x != %04x\n", ret,
+			regnum);
 		return -EINVAL;
 	}
 
@@ -469,6 +478,23 @@ static int mv3310_set_ptp_reg_bits(struct phy_device *phydev, u32 regnum,
 		return ret;
 
 	ret = mv3310_write_ptp_reg(phydev, regnum, regval | bits);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static int mv3310_clear_ptp_reg_bits(struct phy_device *phydev, u32 regnum,
+				     u32 bits)
+{
+	int ret;
+	u32 regval;
+
+	ret = mv3310_read_ptp_reg(phydev, regnum, &regval);
+	if (ret < 0)
+		return ret;
+
+	ret = mv3310_write_ptp_reg(phydev, regnum, regval & ~bits);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
Taking inspiration from MTD API, where both `mtd_msec_ae_init` and `mtd_init_macsec` disable egress drop FIFO, yet keep ingress drop FIFO active. This setting fixes 1588TC time error spikes observed with Calnex.

The drop buffer supports two operation modes, store-and-forward and cut-through. Mode selection
is accomplished by programming `egr_sf_enable`, `igr_sf_enable` field in `slc_cfg_gen` register.
Each buffer (egress and ingress) can have a separate operation mode. In the store-and-forward
mode, the error packets are completely dropped, while non-error packets passing through the drop
buffer incur a propagation delay proportional to their size.
In the cut-through mode, all packets immediately pass through the drop buffer. Error information is
forwarded to the MAC, and the MAC will transmit error packets with a bad CRC to propagate the
error.