### PR TITLE
DEV-7300: marvell10g fix kernel panic if CONFIG_MARVELL_10G_PHY_PTP enabled on regular 88x3310 PHY

### DIFF
--- a/drivers/net/phy/marvell10g.c
+++ b/drivers/net/phy/marvell10g.c
@@ -121,10 +121,10 @@ struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev);
 int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_start(struct mv3310_ptp_priv *priv);
-int mv3310_ptp_get_sset_count(struct phy_device *dev);
-void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data);
-void mv3310_ptp_get_stats(struct phy_device *dev, struct ethtool_stats *stats,
-			  u64 *data, struct mv3310_ptp_priv *priv);
+int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv);
+void mv3310_ptp_get_strings(u8 *data);
+void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+			  struct ethtool_stats *stats, u64 *data);
 #else
 static inline struct mv3310_ptp_priv *
 mv3310_ptp_probe(struct phy_device *phydev)
@@ -143,16 +143,15 @@ static inline int mv3310_ptp_start(struct mv3310_ptp_priv *priv)
 {
 	return 0;
 }
-static inline int mv3310_ptp_get_sset_count(struct phy_device *dev)
+static inline int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv)
 {
 	return 0;
 }
-static inline void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data)
+static inline void mv3310_ptp_get_strings(u8 *data)
 {
 }
-static inline void mv3310_ptp_get_stats(struct phy_device *dev,
-					struct ethtool_stats *stats, u64 *data,
-					struct mv3310_ptp_priv *priv)
+static inline void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+					struct ethtool_stats *stats, u64 *data)
 {
 }
 #endif
@@ -987,19 +986,20 @@ static int mv3310_set_tunable(struct phy_device *phydev,
 
 static int mv3310_get_sset_count(struct phy_device *dev)
 {
-	return mv3310_ptp_get_sset_count(dev);
+	struct mv3310_priv *priv = dev_get_drvdata(&dev->mdio.dev);
+	return mv3310_ptp_get_sset_count(priv->ptp_priv);
 }
 
 static void mv3310_get_strings(struct phy_device *dev, u8 *data)
 {
-	mv3310_ptp_get_strings(dev, data);
+	mv3310_ptp_get_strings(data);
 }
 
 static void mv3310_get_stats(struct phy_device *dev,
 			     struct ethtool_stats *stats, u64 *data)
 {
 	struct mv3310_priv *priv = dev_get_drvdata(&dev->mdio.dev);
-	mv3310_ptp_get_stats(dev, stats, data, priv->ptp_priv);
+	mv3310_ptp_get_stats(priv->ptp_priv, stats, data);
 }
 
 static struct phy_driver mv3310_drivers[] = {

--- a/drivers/net/phy/marvell10g.c
+++ b/drivers/net/phy/marvell10g.c
@@ -576,7 +576,6 @@ static int mv3310_probe(struct phy_device *phydev)
 	if (!priv)
 		return -ENOMEM;
 
-	priv->ptp_priv = mv3310_ptp_probe(phydev);
 	dev_set_drvdata(&phydev->mdio.dev, priv);
 
 	/* Powering down the port when not in use saves about 600mW */
@@ -603,10 +602,15 @@ static int mv3310_suspend(struct phy_device *phydev)
 
 static int mv3310_resume(struct phy_device *phydev)
 {
+	struct mv3310_priv *priv = dev_get_drvdata(&phydev->mdio.dev);
 	int ret;
 
 	ret = mv3310_power_up(phydev);
 	if (ret)
+		return ret;
+
+	ret = mv3310_ptp_start(priv->ptp_priv);
+	if (ret < 0)
 		return ret;
 
 	return mv3310_hwmon_config(phydev, true);
@@ -627,9 +631,13 @@ static int mv3310_start(struct phy_device *phydev)
 	if (ret < 0)
 		return ret;
 
-	ret = mv3310_ptp_start(priv->ptp_priv);
-	if (ret < 0)
-		return ret;
+	/* Probe PTP support.
+	   Ideally it should have been performed under .probe, but PTP
+	   support can only be checked upon completion of reset. */
+	if (!priv->ptp_priv)
+	{
+		priv->ptp_priv = mv3310_ptp_probe(phydev);
+	}
 
 	return 0;
 }

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -248,7 +248,7 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	mutex_lock(&priv->lock);
@@ -282,7 +282,7 @@ unlock_out:
 
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv)
 {
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	return phy_clear_bits_mmd(priv->phydev, MDIO_MMD_VEND2, MV_V2_MODE_CFG,
@@ -294,7 +294,7 @@ int mv3310_ptp_start(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	ret = mv3310_ptp_set_pam(priv);
@@ -335,7 +335,7 @@ unlock_out:
 
 int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv)
 {
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	return ARRAY_SIZE(mv3310_ptp_stats);
@@ -357,7 +357,7 @@ void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
 	int i, ret;
 	u32 regval;
 
-	if (priv == NULL)
+	if (!priv)
 		return;
 
 	mutex_lock(&priv->lock);

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -131,10 +131,10 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_start(struct mv3310_ptp_priv *priv);
 /* Get statistics from the PHY using ethtool */
-int mv3310_ptp_get_sset_count(struct phy_device *dev);
-void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data);
-void mv3310_ptp_get_stats(struct phy_device *dev, struct ethtool_stats *stats,
-			  u64 *data, struct mv3310_ptp_priv *priv);
+int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv);
+void mv3310_ptp_get_strings(u8 *data);
+void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+			  struct ethtool_stats *stats, u64 *data);
 
 /* Helper functions */
 static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
@@ -248,7 +248,7 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (!mv3310_is_ptp_supported(phydev))
+	if (priv == NULL)
 		return 0;
 
 	mutex_lock(&priv->lock);
@@ -282,7 +282,7 @@ unlock_out:
 
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv)
 {
-	if (!mv3310_is_ptp_supported(priv->phydev))
+	if (priv == NULL)
 		return 0;
 
 	return phy_clear_bits_mmd(priv->phydev, MDIO_MMD_VEND2, MV_V2_MODE_CFG,
@@ -294,7 +294,7 @@ int mv3310_ptp_start(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (!mv3310_is_ptp_supported(phydev))
+	if (priv == NULL)
 		return 0;
 
 	ret = mv3310_ptp_set_pam(priv);
@@ -333,15 +333,15 @@ unlock_out:
 	return ret;
 }
 
-int mv3310_ptp_get_sset_count(struct phy_device *dev)
+int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv)
 {
-	if (!mv3310_is_ptp_supported(dev))
+	if (priv == NULL)
 		return 0;
 
 	return ARRAY_SIZE(mv3310_ptp_stats);
 }
 
-void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data)
+void mv3310_ptp_get_strings(u8 *data)
 {
 	int i;
 
@@ -351,19 +351,22 @@ void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data)
 	}
 }
 
-void mv3310_ptp_get_stats(struct phy_device *dev, struct ethtool_stats *stats,
-			  u64 *data, struct mv3310_ptp_priv *priv)
+void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+			  struct ethtool_stats *stats, u64 *data)
 {
 	int i, ret;
 	u32 regval;
 
+	if (priv == NULL)
+		return;
+
 	mutex_lock(&priv->lock);
 
 	for (i = 0; i < ARRAY_SIZE(mv3310_ptp_stats); i++) {
-		ret = mv3310_read_ptp_reg(dev, mv3310_ptp_stats[i].regnum,
-					  &regval);
+		ret = mv3310_read_ptp_reg(priv->phydev,
+					  mv3310_ptp_stats[i].regnum, &regval);
 		if (ret < 0) {
-			dev_err(&dev->mdio.dev,
+			dev_err(&priv->phydev->mdio.dev,
 				"failed to read PTP stat %s: %d\n",
 				mv3310_ptp_stats[i].string, ret);
 			data[i] = 0;

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -187,10 +187,9 @@ static bool mv3310_is_ptp_supported(struct phy_device *phydev)
 	if (ret < 0)
 		return false;
 
-	/* Indication that reset did not yet complete */
 	if (ret == 0) {
 		dev_err(&phydev->mdio.dev,
-			"failed to read XG Extended Status register\n");
+			"XG Ext Status = 0 (reset incomplete)\n");
 		return false;
 	}
 
@@ -202,7 +201,7 @@ struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev)
 	struct mv3310_ptp_priv *priv;
 
 	if (!mv3310_is_ptp_supported(phydev)) {
-		dev_info(&phydev->mdio.dev, "MACSEC/PTP is not present in this device\n");
+		dev_info(&phydev->mdio.dev, "PTP is not present in this device\n");
 		return NULL;
 	}
 

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -183,8 +183,16 @@ static bool mv3310_is_ptp_supported(struct phy_device *phydev)
 	int ret;
 
 	ret = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MV_PMA_XG_EXT_STATUS);
+
 	if (ret < 0)
 		return false;
+
+	/* Indication that reset did not yet complete */
+	if (ret == 0) {
+		dev_err(&phydev->mdio.dev,
+			"failed to read XG Extended Status register\n");
+		return false;
+	}
 
 	return !(ret & MV_PMA_XG_EXT_STATUS_PTP_UNSUPP);
 }
@@ -194,7 +202,7 @@ struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev)
 	struct mv3310_ptp_priv *priv;
 
 	if (!mv3310_is_ptp_supported(phydev)) {
-		dev_info(&phydev->mdio.dev, "PTP is not present in this device\n");
+		dev_info(&phydev->mdio.dev, "MACSEC/PTP is not present in this device\n");
 		return NULL;
 	}
 


### PR DESCRIPTION
This PR fixes two issues:
1. Fix kernel panic in `mv3310_ptp_power_down` as `priv` used to be NULL in case PTP was not supported. Changed all marvell10g_ptp public functions to check whether `priv` was created, instead of going again through `mv3310_is_ptp_supported`.
2. Probe PTP from .start instead of .probe/.config_init, as `mv3310_is_ptp_supported` must be called only upon completion of reset (otherwise  `MV_PMA_XG_EXT_STATUS` returns zero).
