### PR TITLE
DEV-7390: fix PTP register access during admin disable or upon link down

### DIFF
--- a/drivers/net/phy/marvell10g.c
+++ b/drivers/net/phy/marvell10g.c
@@ -121,10 +121,10 @@ struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev);
 int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_start(struct mv3310_ptp_priv *priv);
-int mv3310_ptp_get_sset_count(struct phy_device *dev);
-void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data);
-void mv3310_ptp_get_stats(struct phy_device *dev, struct ethtool_stats *stats,
-			  u64 *data, struct mv3310_ptp_priv *priv);
+int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv);
+void mv3310_ptp_get_strings(u8 *data);
+void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+			  struct ethtool_stats *stats, u64 *data);
 #else
 static inline struct mv3310_ptp_priv *
 mv3310_ptp_probe(struct phy_device *phydev)
@@ -143,16 +143,15 @@ static inline int mv3310_ptp_start(struct mv3310_ptp_priv *priv)
 {
 	return 0;
 }
-static inline int mv3310_ptp_get_sset_count(struct phy_device *dev)
+static inline int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv)
 {
 	return 0;
 }
-static inline void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data)
+static inline void mv3310_ptp_get_strings(u8 *data)
 {
 }
-static inline void mv3310_ptp_get_stats(struct phy_device *dev,
-					struct ethtool_stats *stats, u64 *data,
-					struct mv3310_ptp_priv *priv)
+static inline void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+					struct ethtool_stats *stats, u64 *data)
 {
 }
 #endif
@@ -987,19 +986,20 @@ static int mv3310_set_tunable(struct phy_device *phydev,
 
 static int mv3310_get_sset_count(struct phy_device *dev)
 {
-	return mv3310_ptp_get_sset_count(dev);
+	struct mv3310_priv *priv = dev_get_drvdata(&dev->mdio.dev);
+	return mv3310_ptp_get_sset_count(priv->ptp_priv);
 }
 
 static void mv3310_get_strings(struct phy_device *dev, u8 *data)
 {
-	mv3310_ptp_get_strings(dev, data);
+	mv3310_ptp_get_strings(data);
 }
 
 static void mv3310_get_stats(struct phy_device *dev,
 			     struct ethtool_stats *stats, u64 *data)
 {
 	struct mv3310_priv *priv = dev_get_drvdata(&dev->mdio.dev);
-	mv3310_ptp_get_stats(dev, stats, data, priv->ptp_priv);
+	mv3310_ptp_get_stats(priv->ptp_priv, stats, data);
 }
 
 static struct phy_driver mv3310_drivers[] = {

--- a/drivers/net/phy/marvell10g.c
+++ b/drivers/net/phy/marvell10g.c
@@ -576,7 +576,6 @@ static int mv3310_probe(struct phy_device *phydev)
 	if (!priv)
 		return -ENOMEM;
 
-	priv->ptp_priv = mv3310_ptp_probe(phydev);
 	dev_set_drvdata(&phydev->mdio.dev, priv);
 
 	/* Powering down the port when not in use saves about 600mW */
@@ -603,10 +602,15 @@ static int mv3310_suspend(struct phy_device *phydev)
 
 static int mv3310_resume(struct phy_device *phydev)
 {
+	struct mv3310_priv *priv = dev_get_drvdata(&phydev->mdio.dev);
 	int ret;
 
 	ret = mv3310_power_up(phydev);
 	if (ret)
+		return ret;
+
+	ret = mv3310_ptp_start(priv->ptp_priv);
+	if (ret < 0)
 		return ret;
 
 	return mv3310_hwmon_config(phydev, true);
@@ -627,9 +631,13 @@ static int mv3310_start(struct phy_device *phydev)
 	if (ret < 0)
 		return ret;
 
-	ret = mv3310_ptp_start(priv->ptp_priv);
-	if (ret < 0)
-		return ret;
+	/* Probe PTP support.
+	   Ideally it should have been performed under .probe, but PTP
+	   support can only be checked upon completion of reset. */
+	if (!priv->ptp_priv)
+	{
+		priv->ptp_priv = mv3310_ptp_probe(phydev);
+	}
 
 	return 0;
 }

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -248,7 +248,7 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	mutex_lock(&priv->lock);
@@ -282,7 +282,7 @@ unlock_out:
 
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv)
 {
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	return phy_clear_bits_mmd(priv->phydev, MDIO_MMD_VEND2, MV_V2_MODE_CFG,
@@ -294,7 +294,7 @@ int mv3310_ptp_start(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	ret = mv3310_ptp_set_pam(priv);
@@ -335,7 +335,7 @@ unlock_out:
 
 int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv)
 {
-	if (priv == NULL)
+	if (!priv)
 		return 0;
 
 	return ARRAY_SIZE(mv3310_ptp_stats);
@@ -357,7 +357,7 @@ void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
 	int i, ret;
 	u32 regval;
 
-	if (priv == NULL)
+	if (!priv)
 		return;
 
 	mutex_lock(&priv->lock);

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -131,10 +131,10 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv);
 int mv3310_ptp_start(struct mv3310_ptp_priv *priv);
 /* Get statistics from the PHY using ethtool */
-int mv3310_ptp_get_sset_count(struct phy_device *dev);
-void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data);
-void mv3310_ptp_get_stats(struct phy_device *dev, struct ethtool_stats *stats,
-			  u64 *data, struct mv3310_ptp_priv *priv);
+int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv);
+void mv3310_ptp_get_strings(u8 *data);
+void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+			  struct ethtool_stats *stats, u64 *data);
 
 /* Helper functions */
 static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
@@ -248,7 +248,7 @@ int mv3310_ptp_power_up(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (!mv3310_is_ptp_supported(phydev))
+	if (priv == NULL)
 		return 0;
 
 	mutex_lock(&priv->lock);
@@ -282,7 +282,7 @@ unlock_out:
 
 int mv3310_ptp_power_down(struct mv3310_ptp_priv *priv)
 {
-	if (!mv3310_is_ptp_supported(priv->phydev))
+	if (priv == NULL)
 		return 0;
 
 	return phy_clear_bits_mmd(priv->phydev, MDIO_MMD_VEND2, MV_V2_MODE_CFG,
@@ -294,7 +294,7 @@ int mv3310_ptp_start(struct mv3310_ptp_priv *priv)
 	int ret;
 	struct phy_device *phydev = priv->phydev;
 
-	if (!mv3310_is_ptp_supported(phydev))
+	if (priv == NULL)
 		return 0;
 
 	ret = mv3310_ptp_set_pam(priv);
@@ -333,15 +333,15 @@ unlock_out:
 	return ret;
 }
 
-int mv3310_ptp_get_sset_count(struct phy_device *dev)
+int mv3310_ptp_get_sset_count(struct mv3310_ptp_priv *priv)
 {
-	if (!mv3310_is_ptp_supported(dev))
+	if (priv == NULL)
 		return 0;
 
 	return ARRAY_SIZE(mv3310_ptp_stats);
 }
 
-void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data)
+void mv3310_ptp_get_strings(u8 *data)
 {
 	int i;
 
@@ -351,19 +351,22 @@ void mv3310_ptp_get_strings(struct phy_device *dev, u8 *data)
 	}
 }
 
-void mv3310_ptp_get_stats(struct phy_device *dev, struct ethtool_stats *stats,
-			  u64 *data, struct mv3310_ptp_priv *priv)
+void mv3310_ptp_get_stats(struct mv3310_ptp_priv *priv,
+			  struct ethtool_stats *stats, u64 *data)
 {
 	int i, ret;
 	u32 regval;
 
+	if (priv == NULL)
+		return;
+
 	mutex_lock(&priv->lock);
 
 	for (i = 0; i < ARRAY_SIZE(mv3310_ptp_stats); i++) {
-		ret = mv3310_read_ptp_reg(dev, mv3310_ptp_stats[i].regnum,
-					  &regval);
+		ret = mv3310_read_ptp_reg(priv->phydev,
+					  mv3310_ptp_stats[i].regnum, &regval);
 		if (ret < 0) {
-			dev_err(&dev->mdio.dev,
+			dev_err(&priv->phydev->mdio.dev,
 				"failed to read PTP stat %s: %d\n",
 				mv3310_ptp_stats[i].string, ret);
 			data[i] = 0;

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -201,6 +201,17 @@ static bool mv3310_is_ptp_supported(struct phy_device *phydev)
 	return !(ret & MV_PMA_XG_EXT_STATUS_PTP_UNSUPP);
 }
 
+static bool mv3310_is_ptp_powered_up(struct phy_device *phydev)
+{
+	int ret;
+
+	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, MV_V2_MODE_CFG);
+	if (ret < 0)
+		return false;
+
+	return !!(ret & MV_V2_MODE_CFG_M_UNIT_PWRUP);
+}
+
 struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev)
 {
 	struct mv3310_ptp_priv *priv;
@@ -428,6 +439,10 @@ static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
 {
 	int ret;
 
+	/* If the M unit is powered down its registers are not accessible */
+	if (!mv3310_is_ptp_powered_up(phydev))
+		return -EAGAIN;
+
 	/* Enable workaround for potential PTP register lockup issue */
 	mv3310_ptp_reg_lockup_wa(phydev, true);
 
@@ -441,7 +456,8 @@ static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
 	if (ret < 0)
 		goto disable_wa;
 	if (ret != regnum) {
-		dev_err(&phydev->mdio.dev,
+		dev_err_ratelimited(
+			&phydev->mdio.dev,
 			"Indirect read address mismatch: %04x != %04x\n", ret,
 			regnum);
 		ret = -EINVAL;
@@ -472,6 +488,9 @@ static int mv3310_write_ptp_reg(struct phy_device *phydev, u32 regnum,
 				u32 regval)
 {
 	int ret;
+
+	if (!mv3310_is_ptp_powered_up(phydev))
+		return -EAGAIN;
 
 	/* Enable workaround for potential PTP register lockup issue */
 	mv3310_ptp_reg_lockup_wa(phydev, true);

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -416,7 +416,7 @@ static void mv3310_ptp_reg_lockup_wa(struct phy_device *phydev, bool enable)
 {
 	u16 val = MV_V2_LINK_RESET_CFG_DEF_VAL;
 
-	if (enable)
+	if (!enable)
 		val |= MV_V2_LINK_RESET_CFG_LINK_DOWN;
 
 	phy_write_mmd(phydev, MDIO_MMD_VEND2, MV_V2_LINK_RESET_CFG, val);
@@ -462,6 +462,7 @@ static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
 		goto disable_wa;
 	*regval += ((ret & 0xffff) << 16);
 
+	ret = 0;
 disable_wa:
 	mv3310_ptp_reg_lockup_wa(phydev, false);
 	return ret;
@@ -480,7 +481,10 @@ static int mv3310_write_ptp_reg(struct phy_device *phydev, u32 regnum,
 		goto disable_wa;
 
 	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, regnum + 1, regval >> 16U);
+	if (ret < 0)
+		goto disable_wa;
 
+	ret = 0;
 disable_wa:
 	mv3310_ptp_reg_lockup_wa(phydev, false);
 	return ret;

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -187,10 +187,9 @@ static bool mv3310_is_ptp_supported(struct phy_device *phydev)
 	if (ret < 0)
 		return false;
 
-	/* Indication that reset did not yet complete */
 	if (ret == 0) {
 		dev_err(&phydev->mdio.dev,
-			"failed to read XG Extended Status register\n");
+			"XG Ext Status = 0 (reset incomplete)\n");
 		return false;
 	}
 
@@ -202,7 +201,7 @@ struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev)
 	struct mv3310_ptp_priv *priv;
 
 	if (!mv3310_is_ptp_supported(phydev)) {
-		dev_info(&phydev->mdio.dev, "MACSEC/PTP is not present in this device\n");
+		dev_info(&phydev->mdio.dev, "PTP is not present in this device\n");
 		return NULL;
 	}
 

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -183,8 +183,16 @@ static bool mv3310_is_ptp_supported(struct phy_device *phydev)
 	int ret;
 
 	ret = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MV_PMA_XG_EXT_STATUS);
+
 	if (ret < 0)
 		return false;
+
+	/* Indication that reset did not yet complete */
+	if (ret == 0) {
+		dev_err(&phydev->mdio.dev,
+			"failed to read XG Extended Status register\n");
+		return false;
+	}
 
 	return !(ret & MV_PMA_XG_EXT_STATUS_PTP_UNSUPP);
 }
@@ -194,7 +202,7 @@ struct mv3310_ptp_priv *mv3310_ptp_probe(struct phy_device *phydev)
 	struct mv3310_ptp_priv *priv;
 
 	if (!mv3310_is_ptp_supported(phydev)) {
-		dev_info(&phydev->mdio.dev, "PTP is not present in this device\n");
+		dev_info(&phydev->mdio.dev, "MACSEC/PTP is not present in this device\n");
 		return NULL;
 	}
 

--- a/drivers/net/phy/marvell10g_ptp.c
+++ b/drivers/net/phy/marvell10g_ptp.c
@@ -34,6 +34,11 @@ enum {
 	MV_V2_SLC_CFG_GEN_SMC_STRIP_CRC	= BIT(11),
 	MV_V2_SLC_CFG_GEN_WMC_ANEG_EN	= BIT(23),
 	MV_V2_SLC_CFG_GEN_SMC_ANEG_EN	= BIT(24),
+
+	MV_V2_LINK_RESET_CFG		= 0x80b0,
+	MV_V2_LINK_RESET_CFG_DEF_VAL	= 0x3900,
+	MV_V2_LINK_RESET_CFG_LINK_DOWN	= BIT(0),
+
 	MV_V2_MODE_CFG 			= 0xf000,
 	MV_V2_MODE_CFG_M_UNIT_PWRUP 	= BIT(12),
 
@@ -401,42 +406,65 @@ static int mv3310_verify(struct ptp_clock_info *ptp, unsigned int pin,
 	return -EOPNOTSUPP;
 }
 
+/*
+  Workaround for PTP register lockup issue. When link down reset bit is set, it
+  holds the PTP table registers in reset for a couple of cycles whenever there
+  is a link down event, causing register access failure. To avoid this side
+  effect, clear the reset bit before any PTP register access, then restore it.
+*/
+static void mv3310_ptp_reg_lockup_wa(struct phy_device *phydev, bool enable)
+{
+	u16 val = MV_V2_LINK_RESET_CFG_DEF_VAL;
+
+	if (enable)
+		val |= MV_V2_LINK_RESET_CFG_LINK_DOWN;
+
+	phy_write_mmd(phydev, MDIO_MMD_VEND2, MV_V2_LINK_RESET_CFG, val);
+	phy_write_mmd(phydev, MDIO_MMD_VEND2, MV_V2_LINK_RESET_CFG + 1, 0);
+}
+
 static int mv3310_read_ptp_reg(struct phy_device *phydev, u32 regnum,
 			       u32 *regval)
 {
 	int ret;
 
+	/* Enable workaround for potential PTP register lockup issue */
+	mv3310_ptp_reg_lockup_wa(phydev, true);
+
 	/* Read register address */
 	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, regnum);
 	if (ret < 0)
-		return ret;
+		goto disable_wa;
 
 	/* Read that Indirect_read_address gives requested address */
 	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2, MV_V2_INDIRECT_READ_ADDR);
 	if (ret < 0)
-		return ret;
+		goto disable_wa;
 	if (ret != regnum) {
 		dev_err(&phydev->mdio.dev,
 			"Indirect read address mismatch: %04x != %04x\n", ret,
 			regnum);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto disable_wa;
 	}
 
 	/* Read Indirect_read_data_low provides lower 16-bits (15:0) of data */
 	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2,
 			   MV_V2_INDIRECT_READ_DATA_LOW);
 	if (ret < 0)
-		return ret;
+		goto disable_wa;
 	*regval = ret & 0xffff;
 
 	/* Read Indirect_read_data_high provides upper 16-bits (31:16) of data */
 	ret = phy_read_mmd(phydev, MDIO_MMD_VEND2,
 			   MV_V2_INDIRECT_READ_DATA_HIGH);
 	if (ret < 0)
-		return ret;
+		goto disable_wa;
 	*regval += ((ret & 0xffff) << 16);
 
-	return 0;
+disable_wa:
+	mv3310_ptp_reg_lockup_wa(phydev, false);
+	return ret;
 }
 
 static int mv3310_write_ptp_reg(struct phy_device *phydev, u32 regnum,
@@ -444,15 +472,18 @@ static int mv3310_write_ptp_reg(struct phy_device *phydev, u32 regnum,
 {
 	int ret;
 
+	/* Enable workaround for potential PTP register lockup issue */
+	mv3310_ptp_reg_lockup_wa(phydev, true);
+
 	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, regnum, regval);
 	if (ret < 0)
-		return ret;
+		goto disable_wa;
 
 	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, regnum + 1, regval >> 16U);
-	if (ret < 0)
-		return ret;
 
-	return 0;
+disable_wa:
+	mv3310_ptp_reg_lockup_wa(phydev, false);
+	return ret;
 }
 
 /* The Lookup Action/Match registers need 96-bit write operation */


### PR DESCRIPTION
This PR fixes two issues related to PTP register access:
1. Guard against PTP register access in case the M unit is powered down (e.g. when the interface is admin disabled)
2. On link down event (e.g. cable unplug) there were many `Indirect read address mismatch` errors, indicating some kind of stall in register access. Inspired by MTD API, clearing the link down reset bit in the **undocumented** register 0x80b0 is the workaround for this issue.