### PR TITLE
DEV-7424: cherry-pick IPQ patches from 5.10 to 6.12

### DIFF
--- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
+++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
@@ -28,6 +28,18 @@
 			clock-frequency = <24000000>;
 			#clock-cells = <0>;
 		};
+
+		bias_pll_cc_clk {
+			compatible = "fixed-clock";
+			clock-frequency = <300000000>;
+			#clock-cells = <0>;
+		};
+
+		bias_pll_nss_noc_clk {
+			compatible = "fixed-clock";
+			clock-frequency = <416500000>;
+			#clock-cells = <0>;
+		};
 	};
 
 	cpus: cpus {

--- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
+++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
@@ -424,8 +424,21 @@
 		};
 
 		tcsr: syscon@1937000 {
-			compatible = "qcom,tcsr-ipq6018", "syscon";
+			compatible = "qcom,tcsr-ipq6018", "syscon", "simple-mfd";
 			reg = <0x0 0x01937000 0x0 0x21000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 0x01937000 0x21000>;
+
+			pwm: pwm@a010 {
+				compatible = "qcom,ipq6018-pwm";
+				reg = <0xa010 0x20>;
+				clocks = <&gcc GCC_ADSS_PWM_CLK>;
+				assigned-clocks = <&gcc GCC_ADSS_PWM_CLK>;
+				assigned-clock-rates = <100000000>;
+				#pwm-cells = <2>;
+				status = "disabled";
+			};
 		};
 
 		usb2: usb@70f8800 {

--- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
+++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
@@ -865,6 +865,436 @@
 			};
 		};
 
+		edma@3ab00000 {
+			compatible = "qcom,edma";
+			reg = <0x0 0x3ab00000 0x0 0xabe00>;
+			reg-names = "edma-reg-base";
+			qcom,txdesc-ring-start = <23>;
+			qcom,txdesc-rings = <1>;
+			qcom,txcmpl-ring-start = <23>;
+			qcom,txcmpl-rings = <1>;
+			qcom,rxfill-ring-start = <7>;
+			qcom,rxfill-rings = <1>;
+			qcom,rxdesc-ring-start = <15>;
+			qcom,rxdesc-rings = <1>;
+			interrupts = <0 378 4>,
+				   <0 354 4>,
+				   <0 346 4>,
+				   <0 379 4>;
+			resets = <&gcc GCC_EDMA_HW_RESET>;
+			reset-names = "edma_rst";
+		};
+
+		ess-switch@3a000000 {
+			compatible = "qcom,ess-switch-ipq60xx";
+			/* Single address and size cells. This is required for
+			 * the qca-ssdk driver.
+			 */
+			reg = <0x3a000000 0x1000000>;
+			switch_access_mode = "local bus";
+			clocks = <&gcc GCC_CMN_12GPLL_AHB_CLK>,
+				 <&gcc GCC_CMN_12GPLL_SYS_CLK>,
+				 <&gcc GCC_UNIPHY0_AHB_CLK>,
+				 <&gcc GCC_UNIPHY0_SYS_CLK>,
+				 <&gcc GCC_UNIPHY1_AHB_CLK>,
+				 <&gcc GCC_UNIPHY1_SYS_CLK>,
+				 <&gcc GCC_PORT1_MAC_CLK>,
+				 <&gcc GCC_PORT2_MAC_CLK>,
+				 <&gcc GCC_PORT3_MAC_CLK>,
+				 <&gcc GCC_PORT4_MAC_CLK>,
+				 <&gcc GCC_PORT5_MAC_CLK>,
+				 <&gcc GCC_NSS_PPE_CLK>,
+				 <&gcc GCC_NSS_PPE_CFG_CLK>,
+				 <&gcc GCC_NSSNOC_PPE_CLK>,
+				 <&gcc GCC_NSSNOC_PPE_CFG_CLK>,
+				 <&gcc GCC_NSS_EDMA_CLK>,
+				 <&gcc GCC_NSS_EDMA_CFG_CLK>,
+				 <&gcc GCC_NSS_PPE_IPE_CLK>,
+				 <&gcc GCC_MDIO_AHB_CLK>,
+				 <&gcc GCC_NSS_NOC_CLK>,
+				 <&gcc GCC_NSSNOC_SNOC_CLK>,
+				 <&gcc GCC_NSS_CRYPTO_CLK>,
+				 <&gcc GCC_NSS_PTP_REF_CLK>,
+				 <&gcc GCC_NSS_PORT1_RX_CLK>,
+				 <&gcc GCC_NSS_PORT1_TX_CLK>,
+				 <&gcc GCC_NSS_PORT2_RX_CLK>,
+				 <&gcc GCC_NSS_PORT2_TX_CLK>,
+				 <&gcc GCC_NSS_PORT3_RX_CLK>,
+				 <&gcc GCC_NSS_PORT3_TX_CLK>,
+				 <&gcc GCC_NSS_PORT4_RX_CLK>,
+				 <&gcc GCC_NSS_PORT4_TX_CLK>,
+				 <&gcc GCC_NSS_PORT5_RX_CLK>,
+				 <&gcc GCC_NSS_PORT5_TX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT1_RX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT1_TX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT2_RX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT2_TX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT3_RX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT3_TX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT4_RX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT4_TX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT5_RX_CLK>,
+				 <&gcc GCC_UNIPHY0_PORT5_TX_CLK>,
+				 <&gcc GCC_UNIPHY1_PORT5_RX_CLK>,
+				 <&gcc GCC_UNIPHY1_PORT5_TX_CLK>,
+				 <&gcc NSS_PORT5_RX_CLK_SRC>,
+				 <&gcc NSS_PORT5_TX_CLK_SRC>,
+				 <&gcc GCC_SNOC_NSSNOC_CLK>;
+			clock-names = "cmn_ahb_clk", "cmn_sys_clk",
+					"uniphy0_ahb_clk", "uniphy0_sys_clk",
+					"uniphy1_ahb_clk", "uniphy1_sys_clk",
+					"port1_mac_clk", "port2_mac_clk",
+					"port3_mac_clk", "port4_mac_clk",
+					"port5_mac_clk",
+					"nss_ppe_clk", "nss_ppe_cfg_clk",
+					"nssnoc_ppe_clk", "nssnoc_ppe_cfg_clk",
+					"nss_edma_clk", "nss_edma_cfg_clk",
+					"nss_ppe_ipe_clk",
+					"gcc_mdio_ahb_clk", "gcc_nss_noc_clk",
+					"gcc_nssnoc_snoc_clk",
+					"gcc_nss_crypto_clk",
+					"gcc_nss_ptp_ref_clk",
+					"nss_port1_rx_clk", "nss_port1_tx_clk",
+					"nss_port2_rx_clk", "nss_port2_tx_clk",
+					"nss_port3_rx_clk", "nss_port3_tx_clk",
+					"nss_port4_rx_clk", "nss_port4_tx_clk",
+					"nss_port5_rx_clk", "nss_port5_tx_clk",
+					"uniphy0_port1_rx_clk",
+					"uniphy0_port1_tx_clk",
+					"uniphy0_port2_rx_clk",
+					"uniphy0_port2_tx_clk",
+					"uniphy0_port3_rx_clk",
+					"uniphy0_port3_tx_clk",
+					"uniphy0_port4_rx_clk",
+					"uniphy0_port4_tx_clk",
+					"uniphy0_port5_rx_clk",
+					"uniphy0_port5_tx_clk",
+					"uniphy1_port5_rx_clk",
+					"uniphy1_port5_tx_clk",
+					"nss_port5_rx_clk_src",
+					"nss_port5_tx_clk_src",
+					"gcc_snoc_nssnoc_clk";
+			resets = <&gcc GCC_PPE_FULL_RESET>,
+				 <&gcc GCC_UNIPHY0_SOFT_RESET>,
+				 <&gcc GCC_UNIPHY0_XPCS_RESET>,
+				 <&gcc GCC_UNIPHY1_SOFT_RESET>,
+				 <&gcc GCC_UNIPHY1_XPCS_RESET>,
+				 <&gcc GCC_NSSPORT1_RESET>,
+				 <&gcc GCC_NSSPORT2_RESET>,
+				 <&gcc GCC_NSSPORT3_RESET>,
+				 <&gcc GCC_NSSPORT4_RESET>,
+				 <&gcc GCC_NSSPORT5_RESET>,
+				 <&gcc GCC_UNIPHY0_PORT1_ARES>,
+				 <&gcc GCC_UNIPHY0_PORT2_ARES>,
+				 <&gcc GCC_UNIPHY0_PORT3_ARES>,
+				 <&gcc GCC_UNIPHY0_PORT4_ARES>,
+				 <&gcc GCC_UNIPHY0_PORT5_ARES>,
+				 <&gcc GCC_UNIPHY0_PORT_4_5_RESET>,
+				 <&gcc GCC_UNIPHY0_PORT_4_RESET>;
+			reset-names = "ppe_rst", "uniphy0_soft_rst",
+					"uniphy0_xpcs_rst", "uniphy1_soft_rst",
+					"uniphy1_xpcs_rst", "nss_port1_rst",
+					"nss_port2_rst", "nss_port3_rst",
+					"nss_port4_rst", "nss_port5_rst",
+					"uniphy0_port1_dis",
+					"uniphy0_port2_dis",
+					"uniphy0_port3_dis",
+					"uniphy0_port4_dis",
+					"uniphy0_port5_dis",
+					"uniphy0_port_4_5_rst",
+					"uniphy0_port_4_rst";
+			switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+			switch_lan_bmp = <0x1e>; /* lan port bitmap */
+			switch_wan_bmp = <0x20>; /* wan port bitmap */
+			switch_inner_bmp = <0xc0>; /*inner port bitmap*/
+			switch_mac_mode = <0x0>; /* mac mode for uniphy 0*/
+			switch_mac_mode1 = <0xd>; /* mac mode for uniphy 1*/
+			switch_mac_mode2 = <0xff>; /* mac mode for uniphy 2*/
+			bm_tick_mode = <0>; /* bm tick mode */
+			tm_tick_mode = <0>; /* tm tick mode */
+			port_scheduler_resource {
+				port@0 {
+					port_id = <0>;
+					ucast_queue = <0 143>;
+					mcast_queue = <256 271>;
+					l0sp = <0 35>;
+					l0cdrr = <0 47>;
+					l0edrr = <0 47>;
+					l1cdrr = <0 7>;
+					l1edrr = <0 7>;
+				};
+				port@1 {
+					port_id = <1>;
+					ucast_queue = <144 159>;
+					mcast_queue = <272 275>;
+					l0sp = <36 39>;
+					l0cdrr = <48 63>;
+					l0edrr = <48 63>;
+					l1cdrr = <8 11>;
+					l1edrr = <8 11>;
+				};
+				port@2 {
+					port_id = <2>;
+					ucast_queue = <160 175>;
+					mcast_queue = <276 279>;
+					l0sp = <40 43>;
+					l0cdrr = <64 79>;
+					l0edrr = <64 79>;
+					l1cdrr = <12 15>;
+					l1edrr = <12 15>;
+				};
+				port@3 {
+					port_id = <3>;
+					ucast_queue = <176 191>;
+					mcast_queue = <280 283>;
+					l0sp = <44 47>;
+					l0cdrr = <80 95>;
+					l0edrr = <80 95>;
+					l1cdrr = <16 19>;
+					l1edrr = <16 19>;
+				};
+				port@4 {
+					port_id = <4>;
+					ucast_queue = <192 207>;
+					mcast_queue = <284 287>;
+					l0sp = <48 51>;
+					l0cdrr = <96 111>;
+					l0edrr = <96 111>;
+					l1cdrr = <20 23>;
+					l1edrr = <20 23>;
+				};
+				port@5 {
+					port_id = <5>;
+					ucast_queue = <208 223>;
+					mcast_queue = <288 291>;
+					l0sp = <52 55>;
+					l0cdrr = <112 127>;
+					l0edrr = <112 127>;
+					l1cdrr = <24 27>;
+					l1edrr = <24 27>;
+				};
+				port@6 {
+					port_id = <6>;
+					ucast_queue = <224 239>;
+					mcast_queue = <292 295>;
+					l0sp = <56 59>;
+					l0cdrr = <128 143>;
+					l0edrr = <128 143>;
+					l1cdrr = <28 31>;
+					l1edrr = <28 31>;
+				};
+				port@7 {
+					port_id = <7>;
+					ucast_queue = <240 255>;
+					mcast_queue = <296 299>;
+					l0sp = <60 63>;
+					l0cdrr = <144 159>;
+					l0edrr = <144 159>;
+					l1cdrr = <32 35>;
+					l1edrr = <32 35>;
+				};
+			};
+			port_scheduler_config {
+				port@0 {
+					port_id = <0>;
+					l1scheduler {
+						group@0 {
+							sp = <0 1>; /*L0 SPs*/
+							/*cpri cdrr epri edrr*/
+							cfg = <0 0 0 0>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							/*unicast queues*/
+							ucast_queue = <0 4 8>;
+							/*multicast queues*/
+							mcast_queue = <256 260>;
+							/*sp cpricdrrepriedrr*/
+							cfg = <0 0 0 0 0>;
+						};
+						group@1 {
+							ucast_queue = <1 5 9>;
+							mcast_queue = <257 261>;
+							cfg = <0 1 1 1 1>;
+						};
+						group@2 {
+							ucast_queue = <2 6 10>;
+							mcast_queue = <258 262>;
+							cfg = <0 2 2 2 2>;
+						};
+						group@3 {
+							ucast_queue = <3 7 11>;
+							mcast_queue = <259 263>;
+							cfg = <0 3 3 3 3>;
+						};
+					};
+				};
+				port@1 {
+					port_id = <1>;
+					l1scheduler {
+						group@0 {
+							sp = <36>;
+							cfg = <0 8 0 8>;
+						};
+						group@1 {
+							sp = <37>;
+							cfg = <1 9 1 9>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <144>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <272>;
+							mcast_loop_pri = <4>;
+							cfg = <36 0 48 0 48>;
+						};
+					};
+				};
+				port@2 {
+					port_id = <2>;
+					l1scheduler {
+						group@0 {
+							sp = <40>;
+							cfg = <0 12 0 12>;
+						};
+						group@1 {
+							sp = <41>;
+							cfg = <1 13 1 13>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <160>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <276>;
+							mcast_loop_pri = <4>;
+							cfg = <40 0 64 0 64>;
+						};
+					};
+				};
+				port@3 {
+					port_id = <3>;
+					l1scheduler {
+						group@0 {
+							sp = <44>;
+							cfg = <0 16 0 16>;
+						};
+						group@1 {
+							sp = <45>;
+							cfg = <1 17 1 17>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <176>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <280>;
+							mcast_loop_pri = <4>;
+							cfg = <44 0 80 0 80>;
+						};
+					};
+				};
+				port@4 {
+					port_id = <4>;
+					l1scheduler {
+						group@0 {
+							sp = <48>;
+							cfg = <0 20 0 20>;
+						};
+						group@1 {
+							sp = <49>;
+							cfg = <1 21 1 21>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <192>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <284>;
+							mcast_loop_pri = <4>;
+							cfg = <48 0 96 0 96>;
+						};
+					};
+				};
+				port@5 {
+					port_id = <5>;
+					l1scheduler {
+						group@0 {
+							sp = <52>;
+							cfg = <0 24 0 24>;
+						};
+						group@1 {
+							sp = <53>;
+							cfg = <1 25 1 25>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <208>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <288>;
+							mcast_loop_pri = <4>;
+							cfg = <52 0 112 0 112>;
+						};
+					};
+				};
+				port@6 {
+					port_id = <6>;
+					l1scheduler {
+						group@0 {
+							sp = <56>;
+							cfg = <0 28 0 28>;
+						};
+						group@1 {
+							sp = <57>;
+							cfg = <1 29 1 29>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <224>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <292>;
+							mcast_loop_pri = <4>;
+							cfg = <56 0 128 0 128>;
+						};
+					};
+				};
+				port@7 {
+					port_id = <7>;
+					l1scheduler {
+						group@0 {
+							sp = <60>;
+							cfg = <0 32 0 32>;
+						};
+						group@1 {
+							sp = <61>;
+							cfg = <1 33 1 33>;
+						};
+					};
+					l0scheduler {
+						group@0 {
+							ucast_queue = <240>;
+							ucast_loop_pri = <16>;
+							mcast_queue = <296>;
+							cfg = <60 0 144 0 144>;
+						};
+					};
+				};
+			};
+		};
+
+		ess-uniphy@7a00000 {
+			compatible = "qcom,ess-uniphy";
+			/* Single address and size cells. This is required for
+			 * the qca-ssdk driver.
+			 */
+			reg = <0x7a00000 0x30000>;
+			uniphy_access_mode = "local bus";
+		};
+
 		pcie0: pcie@20000000 {
 			compatible = "qcom,pcie-ipq6018";
 			reg = <0x0 0x20000000 0x0 0xf1d>,

--- a/drivers/clk/qcom/apss-ipq-pll.c
+++ b/drivers/clk/qcom/apss-ipq-pll.c
@@ -22,6 +22,7 @@ static struct clk_alpha_pll ipq_pll_huayra = {
 			},
 			.num_parents = 1,
 			.ops = &clk_alpha_pll_huayra_ops,
+			.flags = CLK_IS_CRITICAL,
 		},
 	},
 };

--- a/drivers/clk/qcom/apss-ipq6018.c
+++ b/drivers/clk/qcom/apss-ipq6018.c
@@ -39,15 +39,21 @@ static const struct parent_map parents_apcs_alias0_clk_src_map[] = {
 	{ P_APSS_PLL_EARLY, 5 },
 };
 
+static const struct freq_tbl ftbl_apcs_alias0_clk_src[] = {
+	{ .src = P_APSS_PLL_EARLY, .pre_div = 1 },
+	{ }
+};
+
 static struct clk_rcg2 apcs_alias0_clk_src = {
 	.cmd_rcgr = 0x0050,
+	.freq_tbl = ftbl_apcs_alias0_clk_src,
 	.hid_width = 5,
 	.parent_map = parents_apcs_alias0_clk_src_map,
 	.clkr.hw.init = &(struct clk_init_data){
 		.name = "apcs_alias0_clk_src",
 		.parent_data = parents_apcs_alias0_clk_src,
 		.num_parents = ARRAY_SIZE(parents_apcs_alias0_clk_src),
-		.ops = &clk_rcg2_mux_closest_ops,
+		.ops = &clk_rcg2_ops,
 		.flags = CLK_SET_RATE_PARENT,
 	},
 };

--- a/drivers/clk/qcom/clk-alpha-pll.c
+++ b/drivers/clk/qcom/clk-alpha-pll.c
@@ -1001,12 +1001,15 @@ static int alpha_pll_huayra_set_rate(struct clk_hw *hw, unsigned long rate,
 	return 0;
 }
 
-static long alpha_pll_huayra_round_rate(struct clk_hw *hw, unsigned long rate,
-					unsigned long *prate)
+static int alpha_pll_huayra_determine_rate(struct clk_hw *hw,
+					   struct clk_rate_request *req )
 {
 	u32 l, a;
 
-	return alpha_huayra_pll_round_rate(rate, *prate, &l, &a);
+	req->rate = alpha_huayra_pll_round_rate(req->rate,
+						req->best_parent_rate,
+			                        &l, &a);
+	return 0;
 }
 
 static int trion_pll_is_enabled(struct clk_alpha_pll *pll,
@@ -1138,7 +1141,7 @@ const struct clk_ops clk_alpha_pll_huayra_ops = {
 	.disable = clk_alpha_pll_disable,
 	.is_enabled = clk_alpha_pll_is_enabled,
 	.recalc_rate = alpha_pll_huayra_recalc_rate,
-	.round_rate = alpha_pll_huayra_round_rate,
+	.determine_rate = alpha_pll_huayra_determine_rate,
 	.set_rate = alpha_pll_huayra_set_rate,
 };
 EXPORT_SYMBOL_GPL(clk_alpha_pll_huayra_ops);

--- a/drivers/clk/qcom/gcc-ipq6018.c
+++ b/drivers/clk/qcom/gcc-ipq6018.c
@@ -212,6 +212,19 @@ static struct clk_rcg2 pcnoc_bfdcd_clk_src = {
 	},
 };
 
+static struct clk_fixed_factor pcnoc_clk_src = {
+	.mult = 1,
+	.div = 1,
+	.hw.init = &(struct clk_init_data){
+		.name = "pcnoc_clk_src",
+		.parent_hws = (const struct clk_hw *[]){
+				&pcnoc_bfdcd_clk_src.clkr.hw },
+		.num_parents = 1,
+		.ops = &clk_fixed_factor_ops,
+		.flags = CLK_SET_RATE_PARENT,
+	},
+};
+
 static struct clk_alpha_pll gpll2_main = {
 	.offset = 0x4a000,
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_DEFAULT],
@@ -487,6 +500,19 @@ static struct clk_rcg2 snoc_nssnoc_bfdcd_clk_src = {
 		.parent_data = gcc_xo_gpll0_gpll6_gpll0_out_main_div2,
 		.num_parents = 4,
 		.ops = &clk_rcg2_ops,
+	},
+};
+
+static struct clk_fixed_factor snoc_nssnoc_clk_src = {
+	.mult = 1,
+	.div = 1,
+	.hw.init = &(struct clk_init_data){
+		.name = "snoc_nssnoc_clk_src",
+		.parent_hws = (const struct clk_hw *[]){
+				&snoc_nssnoc_bfdcd_clk_src.clkr.hw },
+		.num_parents = 1,
+		.ops = &clk_fixed_factor_ops,
+		.flags = CLK_SET_RATE_PARENT,
 	},
 };
 
@@ -1892,6 +1918,19 @@ static struct clk_rcg2 system_noc_bfdcd_clk_src = {
 	},
 };
 
+static struct clk_fixed_factor system_noc_clk_src = {
+	.mult = 1,
+	.div = 1,
+	.hw.init = &(struct clk_init_data){
+		.name = "system_noc_clk_src",
+		.parent_hws = (const struct clk_hw *[]){
+				&system_noc_bfdcd_clk_src.clkr.hw },
+		.num_parents = 1,
+		.ops = &clk_fixed_factor_ops,
+		.flags = CLK_SET_RATE_PARENT,
+	},
+};
+
 static const struct freq_tbl ftbl_ubi32_mem_noc_bfdcd_clk_src[] = {
 	F(24000000, P_XO, 1, 0, 0),
 	F(307670000, P_BIAS_PLL_NSS_NOC, 1.5, 0, 0),
@@ -1924,6 +1963,19 @@ static struct clk_rcg2 ubi32_mem_noc_bfdcd_clk_src = {
 		.parent_data = gcc_xo_gpll0_gpll2_bias_pll_nss_noc_clk,
 		.num_parents = 4,
 		.ops = &clk_rcg2_ops,
+	},
+};
+
+static struct clk_fixed_factor ubi32_mem_noc_clk_src = {
+	.mult = 1,
+	.div = 1,
+	.hw.init = &(struct clk_init_data){
+		.name = "ubi32_mem_noc_clk_src",
+		.parent_hws = (const struct clk_hw *[]){
+				&ubi32_mem_noc_bfdcd_clk_src.clkr.hw },
+		.num_parents = 1,
+		.ops = &clk_fixed_factor_ops,
+		.flags = CLK_SET_RATE_PARENT,
 	},
 };
 
@@ -2684,6 +2736,454 @@ static struct clk_rcg2 lpass_q6_axim_clk_src = {
 	},
 };
 
+static struct clk_branch gcc_wcss_axi_m_clk = {
+	.halt_reg = 0x5903C,
+	.clkr = {
+		.enable_reg = 0x5903C,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_axi_m_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&system_noc_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_sys_noc_wcss_ahb_clk = {
+	.halt_reg = 0x26034,
+	.clkr = {
+		.enable_reg = 0x26034,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_sys_noc_wcss_ahb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&wcss_ahb_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6_axim_clk = {
+	.halt_reg = 0x5913C,
+	.clkr = {
+		.enable_reg = 0x5913C,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6_axim_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&q6_axi_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6ss_atbm_clk = {
+	.halt_reg = 0x59144,
+	.clkr = {
+		.enable_reg = 0x59144,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6ss_atbm_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_at_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6ss_pclkdbg_clk = {
+	.halt_reg = 0x59140,
+	.clkr = {
+		.enable_reg = 0x59140,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6ss_pclkdbg_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_dap_sync_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6_tsctr_1to2_clk = {
+	.halt_reg = 0x59148,
+	.clkr = {
+		.enable_reg = 0x59148,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6_tsctr_1to2_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_tsctr_div2_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_core_tbu_clk = {
+	.halt_reg = 0x12028,
+	.clkr = {
+		.enable_reg = 0xb00c,
+		.enable_mask = BIT(7),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_core_tbu_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&system_noc_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_q6_tbu_clk = {
+	.halt_reg = 0x1202C,
+	.clkr = {
+		.enable_reg = 0xb00c,
+		.enable_mask = BIT(8),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_q6_tbu_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&q6_axi_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6_axim2_clk = {
+	.halt_reg = 0x59150,
+	.clkr = {
+		.enable_reg = 0x59150,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6_axim2_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&q6_axi_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6_ahb_clk = {
+	.halt_reg = 0x59138,
+	.clkr = {
+		.enable_reg = 0x59138,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6_ahb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&wcss_ahb_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_q6_ahb_s_clk = {
+	.halt_reg = 0x5914C,
+	.clkr = {
+		.enable_reg = 0x5914C,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_q6_ahb_s_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&wcss_ahb_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_apb_clk = {
+	.halt_reg = 0x59040,
+	.clkr = {
+		.enable_reg = 0x59040,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_apb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_dap_sync_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_atb_clk = {
+	.halt_reg = 0x59044,
+	.clkr = {
+		.enable_reg = 0x59044,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_atb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_at_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_nts_clk = {
+	.halt_reg = 0x59048,
+	.clkr = {
+		.enable_reg = 0x59048,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_nts_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_tsctr_div2_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_dapbus_clk = {
+	.halt_reg = 0x5905C,
+	.clkr = {
+		.enable_reg = 0x5905C,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_dapbus_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_dap_sync_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_apb_bdg_clk = {
+	.halt_reg = 0x59050,
+	.clkr = {
+		.enable_reg = 0x59050,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_apb_bdg_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_dap_sync_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_atb_bdg_clk = {
+	.halt_reg = 0x59054,
+	.clkr = {
+		.enable_reg = 0x59054,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_atb_bdg_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_at_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_nts_bdg_clk = {
+	.halt_reg = 0x59058,
+	.clkr = {
+		.enable_reg = 0x59058,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_nts_bdg_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_tsctr_div2_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_dbg_ifc_dapbus_bdg_clk = {
+	.halt_reg = 0x59060,
+	.clkr = {
+		.enable_reg = 0x59060,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_dbg_ifc_dapbus_bdg_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_dap_sync_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_nssnoc_atb_clk = {
+	.halt_reg = 0x6818C,
+	.clkr = {
+		.enable_reg = 0x6818C,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_nssnoc_atb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_at_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_ecahb_clk = {
+	.halt_reg = 0x59038,
+	.clkr = {
+		.enable_reg = 0x59038,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_ecahb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&wcss_ahb_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_acmt_clk = {
+	.halt_reg = 0x59064,
+	.clkr = {
+		.enable_reg = 0x59064,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_acmt_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&wcss_ahb_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_wcss_ahb_s_clk = {
+	.halt_reg = 0x59034,
+	.clkr = {
+		.enable_reg = 0x59034,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_wcss_ahb_s_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&wcss_ahb_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+struct clk_branch gcc_rbcpr_wcss_ahb_clk = {
+	.halt_reg = 0x3A008,
+	.clkr = {
+		.enable_reg = 0x3A008,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_rbcpr_wcss_ahb_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&pcnoc_clk_src.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+struct clk_branch gcc_mem_noc_q6_axi_clk = {
+	.halt_reg = 0x1D038,
+	.clkr = {
+		.enable_reg = 0x1D038,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_mem_noc_q6_axi_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&q6_axi_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_sys_noc_qdss_stm_axi_clk = {
+	.halt_reg = 0x26024,
+	.clkr = {
+		.enable_reg = 0x26024,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_sys_noc_qdss_stm_axi_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_stm_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_qdss_stm_clk = {
+	.halt_reg = 0x29044,
+	.clkr = {
+		.enable_reg = 0x29044,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_qdss_stm_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_stm_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
+static struct clk_branch gcc_qdss_traceclkin_clk = {
+	.halt_reg = 0x29060,
+	.clkr = {
+		.enable_reg = 0x29060,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_qdss_traceclkin_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&qdss_traceclkin_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
 static const struct freq_tbl ftbl_rbcpr_wcss_clk_src[] = {
 	F(24000000, P_XO, 1, 0, 0),
 	F(50000000, P_GPLL0, 16, 0, 0),
@@ -2702,6 +3202,23 @@ static struct clk_rcg2 rbcpr_wcss_clk_src = {
 		.ops = &clk_rcg2_ops,
 	},
 };
+
+struct clk_branch gcc_rbcpr_wcss_clk = {
+	.halt_reg = 0x3A004,
+	.clkr = {
+		.enable_reg = 0x3A004,
+		.enable_mask = BIT(0),
+		.hw.init = &(struct clk_init_data){
+			.name = "gcc_rbcpr_wcss_clk",
+			.parent_hws = (const struct clk_hw *[]){
+					&rbcpr_wcss_clk_src.clkr.hw },
+			.num_parents = 1,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
+			.ops = &clk_branch2_ops,
+		},
+	},
+};
+
 
 static struct clk_branch gcc_lpass_core_axim_clk = {
 	.halt_reg = 0x1F028,
@@ -4216,6 +4733,9 @@ static struct clk_hw *gcc_ipq6018_hws[] = {
 	&gpll6_out_main_div2.hw,
 	&qdss_dap_sync_clk_src.hw,
 	&qdss_tsctr_div2_clk_src.hw,
+	&pcnoc_clk_src.hw,
+	&snoc_nssnoc_clk_src.hw,
+	&ubi32_mem_noc_clk_src.hw,
 };
 
 static struct clk_regmap *gcc_ipq6018_clks[] = {
@@ -4421,9 +4941,35 @@ static struct clk_regmap *gcc_ipq6018_clks[] = {
 	[PCIE0_RCHNG_CLK_SRC] = &pcie0_rchng_clk_src.clkr,
 	[GCC_PCIE0_AXI_S_BRIDGE_CLK] = &gcc_pcie0_axi_s_bridge_clk.clkr,
 	[PCIE0_RCHNG_CLK] = &gcc_pcie0_rchng_clk.clkr,
+	[GCC_WCSS_AXI_M_CLK] = &gcc_wcss_axi_m_clk.clkr,
+	[GCC_SYS_NOC_WCSS_AHB_CLK] = &gcc_sys_noc_wcss_ahb_clk.clkr,
 	[WCSS_AHB_CLK_SRC] = &wcss_ahb_clk_src.clkr,
+	[GCC_Q6_AXIM_CLK] = &gcc_q6_axim_clk.clkr,
 	[Q6_AXI_CLK_SRC] = &q6_axi_clk_src.clkr,
+	[GCC_Q6SS_ATBM_CLK] = &gcc_q6ss_atbm_clk.clkr,
+	[GCC_Q6SS_PCLKDBG_CLK] = &gcc_q6ss_pclkdbg_clk.clkr,
+	[GCC_Q6_TSCTR_1TO2_CLK] = &gcc_q6_tsctr_1to2_clk.clkr,
+	[GCC_WCSS_CORE_TBU_CLK] = &gcc_wcss_core_tbu_clk.clkr,
+	[GCC_WCSS_Q6_TBU_CLK] = &gcc_wcss_q6_tbu_clk.clkr,
+	[GCC_Q6_AXIM2_CLK] = &gcc_q6_axim2_clk.clkr,
+	[GCC_Q6_AHB_CLK] = &gcc_q6_ahb_clk.clkr,
+	[GCC_Q6_AHB_S_CLK] = &gcc_q6_ahb_s_clk.clkr,
+	[GCC_WCSS_DBG_IFC_APB_CLK] = &gcc_wcss_dbg_ifc_apb_clk.clkr,
+	[GCC_WCSS_DBG_IFC_ATB_CLK] = &gcc_wcss_dbg_ifc_atb_clk.clkr,
+	[GCC_WCSS_DBG_IFC_NTS_CLK] = &gcc_wcss_dbg_ifc_nts_clk.clkr,
+	[GCC_WCSS_DBG_IFC_DAPBUS_CLK] = &gcc_wcss_dbg_ifc_dapbus_clk.clkr,
+	[GCC_WCSS_DBG_IFC_APB_BDG_CLK] = &gcc_wcss_dbg_ifc_apb_bdg_clk.clkr,
+	[GCC_WCSS_DBG_IFC_ATB_BDG_CLK] = &gcc_wcss_dbg_ifc_atb_bdg_clk.clkr,
+	[GCC_WCSS_DBG_IFC_NTS_BDG_CLK] = &gcc_wcss_dbg_ifc_nts_bdg_clk.clkr,
+	[GCC_WCSS_DBG_IFC_DAPBUS_BDG_CLK] = &gcc_wcss_dbg_ifc_dapbus_bdg_clk.clkr,
+	[GCC_NSSNOC_ATB_CLK] = &gcc_nssnoc_atb_clk.clkr,
+	[GCC_WCSS_ECAHB_CLK] = &gcc_wcss_ecahb_clk.clkr,
+	[GCC_WCSS_ACMT_CLK] = &gcc_wcss_acmt_clk.clkr,
+	[GCC_WCSS_AHB_S_CLK] = &gcc_wcss_ahb_s_clk.clkr,
+	[GCC_RBCPR_WCSS_CLK] = &gcc_rbcpr_wcss_clk.clkr,
 	[RBCPR_WCSS_CLK_SRC] = &rbcpr_wcss_clk_src.clkr,
+	[GCC_RBCPR_WCSS_AHB_CLK] = &gcc_rbcpr_wcss_ahb_clk.clkr,
+	[GCC_MEM_NOC_Q6_AXI_CLK] = &gcc_mem_noc_q6_axi_clk.clkr,
 	[GCC_LPASS_CORE_AXIM_CLK] = &gcc_lpass_core_axim_clk.clkr,
 	[LPASS_CORE_AXIM_CLK_SRC] = &lpass_core_axim_clk_src.clkr,
 	[GCC_LPASS_SNOC_CFG_CLK] = &gcc_lpass_snoc_cfg_clk.clkr,
@@ -4439,6 +4985,9 @@ static struct clk_regmap *gcc_ipq6018_clks[] = {
 	[GCC_MEM_NOC_UBI32_CLK] = &gcc_mem_noc_ubi32_clk.clkr,
 	[GCC_MEM_NOC_LPASS_CLK] = &gcc_mem_noc_lpass_clk.clkr,
 	[GCC_SNOC_LPASS_CFG_CLK] = &gcc_snoc_lpass_cfg_clk.clkr,
+	[GCC_SYS_NOC_QDSS_STM_AXI_CLK] = &gcc_sys_noc_qdss_stm_axi_clk.clkr,
+	[GCC_QDSS_STM_CLK] = &gcc_qdss_stm_clk.clkr,
+	[GCC_QDSS_TRACECLKIN_CLK] = &gcc_qdss_traceclkin_clk.clkr,
 	[QDSS_STM_CLK_SRC] = &qdss_stm_clk_src.clkr,
 	[QDSS_TRACECLKIN_CLK_SRC] = &qdss_traceclkin_clk_src.clkr,
 };
@@ -4619,7 +5168,12 @@ static const struct qcom_cc_desc gcc_ipq6018_desc = {
 
 static int gcc_ipq6018_probe(struct platform_device *pdev)
 {
+	int ret;
 	struct regmap *regmap;
+	struct device *dev = &pdev->dev;
+
+	clk_register_fixed_rate(dev, "pcie20_phy0_pipe_clk", NULL, 0,
+							250000000);
 
 	regmap = qcom_cc_map(pdev, &gcc_ipq6018_desc);
 	if (IS_ERR(regmap))
@@ -4642,13 +5196,23 @@ static int gcc_ipq6018_probe(struct platform_device *pdev)
 	clk_alpha_pll_configure(&nss_crypto_pll_main, regmap,
 				&nss_crypto_pll_config);
 
-	return qcom_cc_really_probe(&pdev->dev, &gcc_ipq6018_desc, regmap);
+	ret = qcom_cc_really_probe(&pdev->dev, &gcc_ipq6018_desc, regmap);
+
+	dev_dbg(&pdev->dev, "Registered ipq6018 clock provider");
+
+	return ret;
+}
+
+static void gcc_ipq6018_remove(struct platform_device *pdev)
+{
 }
 
 static struct platform_driver gcc_ipq6018_driver = {
 	.probe = gcc_ipq6018_probe,
+	.remove = gcc_ipq6018_remove,
 	.driver = {
 		.name   = "qcom,gcc-ipq6018",
+		.owner  = THIS_MODULE,
 		.of_match_table = gcc_ipq6018_match_table,
 	},
 };

--- a/drivers/clk/qcom/gcc-ipq6018.c
+++ b/drivers/clk/qcom/gcc-ipq6018.c
@@ -89,7 +89,7 @@ static struct clk_alpha_pll_postdiv gpll0 = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_gpll0_out_main_div2[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw},
 	{ .hw = &gpll0_out_main_div2.hw},
 };
@@ -280,7 +280,7 @@ static const struct freq_tbl ftbl_qdss_tsctr_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll4_gpll0_gpll6_gpll0_div2[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll4.clkr.hw },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll6.clkr.hw },
@@ -359,8 +359,8 @@ static const struct freq_tbl ftbl_nss_ppe_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_bias_gpll0_gpll4_nss_ubi32[] = {
-	{ .fw_name = "xo" },
-	{ .fw_name = "bias_pll_cc_clk" },
+	{ .fw_name = "xo", .name = "xo" },
+	{ .fw_name = "bias_pll_cc_clk", .name = "bias_pll_cc_clk" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll4.clkr.hw },
 	{ .hw = &nss_crypto_pll.clkr.hw },
@@ -525,13 +525,13 @@ static const struct freq_tbl ftbl_nss_port5_rx_clk_src[] = {
 
 static const struct clk_parent_data
 gcc_xo_uniphy0_rx_tx_uniphy1_rx_tx_ubi32_bias[] = {
-	{ .fw_name = "xo" },
-	{ .fw_name = "uniphy0_gcc_rx_clk" },
-	{ .fw_name = "uniphy0_gcc_tx_clk" },
-	{ .fw_name = "uniphy1_gcc_rx_clk" },
-	{ .fw_name = "uniphy1_gcc_tx_clk" },
+	{ .fw_name = "xo", .name = "xo" },
+	{ .fw_name = "uniphy0_gcc_rx_clk", .name = "uniphy0_gcc_rx_clk" },
+	{ .fw_name = "uniphy0_gcc_tx_clk", .name = "uniphy0_gcc_tx_clk" },
+	{ .fw_name = "uniphy1_gcc_rx_clk", .name = "uniphy1_gcc_rx_clk" },
+	{ .fw_name = "uniphy1_gcc_tx_clk", .name = "uniphy1_gcc_tx_clk" },
 	{ .hw = &ubi32_pll.clkr.hw },
-	{ .fw_name = "bias_pll_cc_clk" },
+	{ .fw_name = "bias_pll_cc_clk", .name = "bias_pll_cc_clk" },
 };
 
 static const struct parent_map
@@ -572,13 +572,13 @@ static const struct freq_tbl ftbl_nss_port5_tx_clk_src[] = {
 
 static const struct clk_parent_data
 gcc_xo_uniphy0_tx_rx_uniphy1_tx_rx_ubi32_bias[] = {
-	{ .fw_name = "xo" },
-	{ .fw_name = "uniphy0_gcc_tx_clk" },
-	{ .fw_name = "uniphy0_gcc_rx_clk" },
-	{ .fw_name = "uniphy1_gcc_tx_clk" },
-	{ .fw_name = "uniphy1_gcc_rx_clk" },
+	{ .fw_name = "xo", .name = "xo" },
+	{ .fw_name = "uniphy0_gcc_tx_clk", .name = "uniphy0_gcc_tx_clk" },
+	{ .fw_name = "uniphy0_gcc_rx_clk", .name = "uniphy0_gcc_rx_clk" },
+	{ .fw_name = "uniphy1_gcc_tx_clk", .name = "uniphy1_gcc_tx_clk"},
+	{ .fw_name = "uniphy1_gcc_rx_clk", .name = "uniphy1_gcc_rx_clk" },
 	{ .hw = &ubi32_pll.clkr.hw },
-	{ .fw_name = "bias_pll_cc_clk" },
+	{ .fw_name = "bias_pll_cc_clk", .name = "bias_pll_cc_clk" },
 };
 
 static const struct parent_map
@@ -619,7 +619,7 @@ static const struct freq_tbl ftbl_pcie_rchng_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_gpll4[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll4.clkr.hw },
 };
@@ -652,7 +652,7 @@ static const struct freq_tbl ftbl_usb0_master_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_out_main_div2_gpll0[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0_out_main_div2.hw },
 	{ .hw = &gpll0.clkr.hw },
 };
@@ -713,11 +713,11 @@ static const struct freq_tbl ftbl_nss_port1_rx_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_uniphy0_rx_tx_ubi32_bias[] = {
-	{ .fw_name = "xo" },
-	{ .fw_name = "uniphy0_gcc_rx_clk" },
-	{ .fw_name = "uniphy0_gcc_tx_clk" },
+	{ .fw_name = "xo", .name = "xo" },
+	{ .fw_name = "uniphy0_gcc_rx_clk", .name = "uniphy0_gcc_rx_clk" },
+	{ .fw_name = "uniphy0_gcc_tx_clk", .name = "uniphy0_gcc_tx_clk" },
 	{ .hw = &ubi32_pll.clkr.hw },
-	{ .fw_name = "bias_pll_cc_clk" },
+	{ .fw_name = "bias_pll_cc_clk", .name = "bias_pll_cc_clk" },
 };
 
 static const struct parent_map gcc_xo_uniphy0_rx_tx_ubi32_bias_map[] = {
@@ -749,11 +749,11 @@ static const struct freq_tbl ftbl_nss_port1_tx_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_uniphy0_tx_rx_ubi32_bias[] = {
-	{ .fw_name = "xo" },
-	{ .fw_name = "uniphy0_gcc_tx_clk" },
-	{ .fw_name = "uniphy0_gcc_rx_clk" },
+	{ .fw_name = "xo", .name = "xo" },
+	{ .fw_name = "uniphy0_gcc_tx_clk", .name = "uniphy0_gcc_tx_clk" },
+	{ .fw_name = "uniphy0_gcc_rx_clk", .name = "uniphy0_gcc_rx_clk" },
 	{ .hw = &ubi32_pll.clkr.hw },
-	{ .fw_name = "bias_pll_cc_clk" },
+	{ .fw_name = "bias_pll_cc_clk", .name = "bias_pll_cc_clk" },
 };
 
 static const struct parent_map gcc_xo_uniphy0_tx_rx_ubi32_bias_map[] = {
@@ -898,7 +898,7 @@ static const struct freq_tbl ftbl_apss_axi_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_gpll6_ubi32_gpll0_div2[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll6.clkr.hw },
 	{ .hw = &ubi32_pll.clkr.hw },
@@ -934,7 +934,7 @@ static const struct freq_tbl ftbl_nss_crypto_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_nss_crypto_pll_gpll0[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &nss_crypto_pll.clkr.hw },
 	{ .hw = &gpll0.clkr.hw },
 };
@@ -1100,7 +1100,7 @@ static const struct freq_tbl ftbl_nss_ubi_clk_src[] = {
 
 static const struct clk_parent_data
 			gcc_xo_ubi32_pll_gpll0_gpll2_gpll4_gpll6[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &ubi32_pll.clkr.hw },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll2.clkr.hw },
@@ -1466,11 +1466,11 @@ static const struct freq_tbl ftbl_gp_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_gpll6_gpll0_sleep_clk[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll6.clkr.hw },
 	{ .hw = &gpll0_out_main_div2.hw },
-	{ .fw_name = "sleep_clk" },
+	{ .fw_name = "sleep_clk", .name = "sleep_clk" },
 };
 
 static const struct parent_map gcc_xo_gpll0_gpll6_gpll0_sleep_clk_map[] = {
@@ -1558,9 +1558,9 @@ static const struct freq_tbl ftbl_pcie_aux_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_core_pi_sleep_clk[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
-	{ .fw_name = "sleep_clk" },
+	{ .fw_name = "sleep_clk", .name = "sleep_clk" },
 };
 
 static const struct parent_map gcc_xo_gpll0_core_pi_sleep_clk_map[] = {
@@ -1584,8 +1584,8 @@ static struct clk_rcg2 pcie0_aux_clk_src = {
 };
 
 static const struct clk_parent_data gcc_pcie20_phy0_pipe_clk_xo[] = {
-	{ .fw_name = "pcie20_phy0_pipe_clk" },
-	{ .fw_name = "xo" },
+	{ .fw_name = "pcie20_phy0_pipe_clk", .name = "pcie20_phy0_pipe_clk" },
+	{ .fw_name = "xo", .name = "xo" },
 };
 
 static const struct parent_map gcc_pcie20_phy0_pipe_clk_xo_map[] = {
@@ -1623,7 +1623,7 @@ static const struct freq_tbl ftbl_sdcc_apps_clk_src[] = {
 
 static const struct clk_parent_data
 			gcc_xo_gpll0_gpll2_gpll0_out_main_div2[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll2.clkr.hw },
 	{ .hw = &gpll0_out_main_div2.hw },
@@ -1677,7 +1677,7 @@ static const struct freq_tbl ftbl_usb_mock_utmi_clk_src[] = {
 
 static const struct clk_parent_data
 			gcc_xo_gpll6_gpll0_gpll0_out_main_div2[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll6.clkr.hw },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll0_out_main_div2.hw },
@@ -1705,8 +1705,8 @@ static struct clk_rcg2 usb0_mock_utmi_clk_src = {
 };
 
 static const struct clk_parent_data gcc_usb3phy_0_cc_pipe_clk_xo[] = {
-	{ .fw_name = "usb3phy_0_cc_pipe_clk" },
-	{ .fw_name = "xo" },
+	{ .fw_name = "usb3phy_0_cc_pipe_clk", .name = "usb3phy_0_cc_pipe_clk" },
+	{ .fw_name = "xo", .name = "xo" },
 };
 
 static const struct parent_map gcc_usb3phy_0_cc_pipe_clk_xo_map[] = {
@@ -1739,7 +1739,7 @@ static const struct freq_tbl ftbl_sdcc_ice_core_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_gpll6_gpll0_div2[] = {
-	{ .fw_name = "xo"},
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll6.clkr.hw },
 	{ .hw = &gpll0_out_main_div2.hw },
@@ -1795,7 +1795,7 @@ static const struct freq_tbl ftbl_qdss_traceclkin_clk_src[] = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll4_gpll0_gpll0_div2[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll4.clkr.hw },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll0_out_main_div2.hw },
@@ -1901,10 +1901,10 @@ static const struct freq_tbl ftbl_ubi32_mem_noc_bfdcd_clk_src[] = {
 
 static const struct clk_parent_data
 			gcc_xo_gpll0_gpll2_bias_pll_nss_noc_clk[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll2.clkr.hw },
-	{ .fw_name = "bias_pll_nss_noc_clk" },
+	{ .fw_name = "bias_pll_nss_noc_clk", .name = "bias_pll_nss_noc_clk" },
 };
 
 static const struct parent_map gcc_xo_gpll0_gpll2_bias_pll_nss_noc_clk_map[] = {
@@ -2599,7 +2599,7 @@ static struct clk_rcg2 wcss_ahb_clk_src = {
 };
 
 static const struct clk_parent_data gcc_xo_gpll0_gpll2_gpll4_gpll6[] = {
-	{ .fw_name = "xo" },
+	{ .fw_name = "xo", .name = "xo" },
 	{ .hw = &gpll0.clkr.hw },
 	{ .hw = &gpll2.clkr.hw },
 	{ .hw = &gpll4.clkr.hw },

--- a/drivers/clk/qcom/gcc-ipq6018.c
+++ b/drivers/clk/qcom/gcc-ipq6018.c
@@ -4067,7 +4067,7 @@ static struct clk_branch gcc_qdss_dap_clk = {
 			.parent_hws = (const struct clk_hw *[]){
 					&qdss_dap_sync_clk_src.hw },
 			.num_parents = 1,
-			.flags = CLK_SET_RATE_PARENT,
+			.flags = CLK_SET_RATE_PARENT | CLK_IS_CRITICAL,
 			.ops = &clk_branch2_ops,
 		},
 	},

--- a/drivers/mtd/parsers/qcomsmempart.c
+++ b/drivers/mtd/parsers/qcomsmempart.c
@@ -64,6 +64,15 @@ static int parse_qcomsmem_part(struct mtd_info *mtd,
 	struct smem_flash_ptable *ptable;
 	struct mtd_partition *parts;
 	char *name, *c;
+	uint32_t block_size = mtd->erasesize;
+
+	/*
+	 * We have no access to true hardware block size when 4K sectors
+	 * support is enabled. Use 64K as this is the most common size.
+	 */
+	if (IS_ENABLED(CONFIG_MTD_SPI_NOR_USE_4K_SECTORS)
+			&& mtd->type == MTD_NORFLASH)
+		block_size = 64 * 1024;
 
 	if (IS_ENABLED(CONFIG_MTD_SPI_NOR_USE_4K_SECTORS)
 			&& mtd->type == MTD_NORFLASH) {
@@ -143,9 +152,9 @@ static int parse_qcomsmem_part(struct mtd_info *mtd,
 			*c = tolower(*c);
 
 		parts[j].name = name;
-		parts[j].offset = le32_to_cpu(pentry->offset) * mtd->erasesize;
+		parts[j].offset = le32_to_cpu(pentry->offset) * block_size;
 		parts[j].mask_flags = pentry->attr;
-		parts[j].size = le32_to_cpu(pentry->length) * mtd->erasesize;
+		parts[j].size = le32_to_cpu(pentry->length) * block_size;
 		pr_debug("%d: %s offs=0x%08x size=0x%08x attr:0x%08x\n",
 			 i, pentry->name, le32_to_cpu(pentry->offset),
 			 le32_to_cpu(pentry->length), pentry->attr);

--- a/drivers/mtd/parsers/qcomsmempart.c
+++ b/drivers/mtd/parsers/qcomsmempart.c
@@ -74,13 +74,6 @@ static int parse_qcomsmem_part(struct mtd_info *mtd,
 			&& mtd->type == MTD_NORFLASH)
 		block_size = 64 * 1024;
 
-	if (IS_ENABLED(CONFIG_MTD_SPI_NOR_USE_4K_SECTORS)
-			&& mtd->type == MTD_NORFLASH) {
-		pr_err("%s: SMEM partition parser is incompatible with 4K sectors\n",
-				mtd->name);
-		return -EINVAL;
-	}
-
 	pr_debug("Parsing partition table info from SMEM\n");
 	ptable = qcom_smem_get(SMEM_APPS, SMEM_AARM_PARTITION_TABLE, &len);
 	if (IS_ERR(ptable)) {

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -319,6 +319,18 @@ config PWM_INTEL_LGM
 	  To compile this driver as a module, choose M here: the module
 	  will be called pwm-intel-lgm.
 
+config PWM_IPQ
+	tristate "IPQ PWM support"
+	depends on ARCH_QCOM || COMPILE_TEST
+	depends on HAVE_CLK && HAS_IOMEM
+	help
+	  Generic PWM framework driver for IPQ PWM block which supports
+	  4 pwm channels. Each of the these channels can be configured
+	  independent of each other.
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called pwm-ipq.
+
 config PWM_IQS620A
 	tristate "Azoteq IQS620A PWM support"
 	depends on MFD_IQS62X || COMPILE_TEST

--- a/drivers/pwm/Makefile
+++ b/drivers/pwm/Makefile
@@ -27,6 +27,7 @@ obj-$(CONFIG_PWM_IMX1)		+= pwm-imx1.o
 obj-$(CONFIG_PWM_IMX27)		+= pwm-imx27.o
 obj-$(CONFIG_PWM_IMX_TPM)	+= pwm-imx-tpm.o
 obj-$(CONFIG_PWM_INTEL_LGM)	+= pwm-intel-lgm.o
+obj-$(CONFIG_PWM_IPQ)		+= pwm-ipq.o
 obj-$(CONFIG_PWM_IQS620A)	+= pwm-iqs620a.o
 obj-$(CONFIG_PWM_JZ4740)	+= pwm-jz4740.o
 obj-$(CONFIG_PWM_KEEMBAY)	+= pwm-keembay.o

--- a/drivers/pwm/pwm-ipq.c
+++ b/drivers/pwm/pwm-ipq.c
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+/*
+ * Copyright (c) 2016-2017, 2020 The Linux Foundation. All rights reserved.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/pwm.h>
+#include <linux/clk.h>
+#include <linux/io.h>
+#include <linux/of.h>
+#include <linux/math64.h>
+#include <linux/of_device.h>
+#include <linux/bitfield.h>
+
+/* The frequency range supported is 1 Hz to clock rate */
+#define IPQ_PWM_MAX_PERIOD_NS	((u64)NSEC_PER_SEC)
+
+/*
+ * The max value specified for each field is based on the number of bits
+ * in the pwm control register for that field
+ */
+#define IPQ_PWM_MAX_DIV		0xFFFF
+
+/*
+ * Two 32-bit registers for each PWM: REG0, and REG1.
+ * Base offset for PWM #i is at 8 * #i.
+ */
+#define IPQ_PWM_REG0			0 /*PWM_DIV PWM_HI*/
+#define IPQ_PWM_REG0_PWM_DIV		GENMASK(15, 0)
+#define IPQ_PWM_REG0_HI_DURATION	GENMASK(31, 16)
+
+#define IPQ_PWM_REG1			4 /*ENABLE UPDATE PWM_PRE_DIV*/
+#define IPQ_PWM_REG1_PRE_DIV		GENMASK(15, 0)
+/*
+ * Enable bit is set to enable output toggling in pwm device.
+ * Update bit is set to reflect the changed divider and high duration
+ * values in register.
+ */
+#define IPQ_PWM_REG1_UPDATE		BIT(30)
+#define IPQ_PWM_REG1_ENABLE		BIT(31)
+
+
+struct ipq_pwm_chip {
+	struct pwm_chip chip;
+	struct clk *clk;
+	void __iomem *mem;
+};
+
+static struct ipq_pwm_chip *ipq_pwm_from_chip(struct pwm_chip *chip)
+{
+	return container_of(chip, struct ipq_pwm_chip, chip);
+}
+
+static unsigned int ipq_pwm_reg_read(struct pwm_device *pwm, unsigned int reg)
+{
+	struct ipq_pwm_chip *ipq_chip = ipq_pwm_from_chip(pwm->chip);
+	unsigned int off = 8 * pwm->hwpwm + reg;
+
+	return readl(ipq_chip->mem + off);
+}
+
+static void ipq_pwm_reg_write(struct pwm_device *pwm, unsigned int reg,
+			      unsigned int val)
+{
+	struct ipq_pwm_chip *ipq_chip = ipq_pwm_from_chip(pwm->chip);
+	unsigned int off = 8 * pwm->hwpwm + reg;
+
+	writel(val, ipq_chip->mem + off);
+}
+
+static void config_div_and_duty(struct pwm_device *pwm, unsigned int pre_div,
+			unsigned int pwm_div, unsigned long rate, u64 duty_ns,
+			bool enable)
+{
+	unsigned long hi_dur;
+	unsigned long val = 0;
+
+	/*
+	 * high duration = pwm duty * (pwm div + 1)
+	 * pwm duty = duty_ns / period_ns
+	 */
+	hi_dur = div64_u64(duty_ns * rate, (pre_div + 1) * NSEC_PER_SEC);
+
+	val = FIELD_PREP(IPQ_PWM_REG0_HI_DURATION, hi_dur) |
+		FIELD_PREP(IPQ_PWM_REG0_PWM_DIV, pwm_div);
+	ipq_pwm_reg_write(pwm, IPQ_PWM_REG0, val);
+
+	val = FIELD_PREP(IPQ_PWM_REG1_PRE_DIV, pre_div);
+	ipq_pwm_reg_write(pwm, IPQ_PWM_REG1, val);
+
+	/* PWM enable toggle needs a separate write to REG1 */
+	val |= IPQ_PWM_REG1_UPDATE;
+	if (enable)
+		val |= IPQ_PWM_REG1_ENABLE;
+	ipq_pwm_reg_write(pwm, IPQ_PWM_REG1, val);
+}
+
+static int ipq_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
+			 const struct pwm_state *state)
+{
+	struct ipq_pwm_chip *ipq_chip = ipq_pwm_from_chip(chip);
+	unsigned int pre_div, pwm_div, best_pre_div, best_pwm_div;
+	unsigned long rate = clk_get_rate(ipq_chip->clk);
+	u64 period_ns, duty_ns, period_rate;
+	u64 min_diff;
+
+	if (state->polarity != PWM_POLARITY_NORMAL)
+		return -EINVAL;
+
+	if (state->period < div64_u64(NSEC_PER_SEC, rate))
+		return -ERANGE;
+
+	period_ns = min(state->period, IPQ_PWM_MAX_PERIOD_NS);
+	duty_ns = min(state->duty_cycle, period_ns);
+
+	/*
+	 * period_ns is 1G or less. As long as rate is less than 16 GHz this
+	 * does not overflow.
+	 */
+	period_rate = period_ns * rate;
+	best_pre_div = IPQ_PWM_MAX_DIV;
+	best_pwm_div = IPQ_PWM_MAX_DIV;
+	/* Initial pre_div value such that pwm_div < IPQ_PWM_MAX_DIV */
+	pre_div = div64_u64(period_rate,
+			(u64)NSEC_PER_SEC * (IPQ_PWM_MAX_DIV + 1));
+	min_diff = period_rate;
+
+	for (; pre_div <= IPQ_PWM_MAX_DIV; pre_div++) {
+		long long diff;
+
+		pwm_div = DIV64_U64_ROUND_UP(period_rate,
+				(u64)NSEC_PER_SEC * (pre_div + 1));
+		/* pwm_div is unsigned; the check below catches underflow */
+		pwm_div--;
+
+		/*
+		 * pre_div and pwm_div values swap produces the same
+		 * result. This loop goes over all pre_div <= pwm_div
+		 * combinations. The rest are equivalent.
+		 */
+		if (pre_div > pwm_div)
+			break;
+
+		/*
+		 * Make sure we can do 100% duty cycle where
+		 * hi_dur == pwm_div + 1
+		 */
+		if (pwm_div > IPQ_PWM_MAX_DIV - 1)
+			continue;
+
+		diff = ((uint64_t)NSEC_PER_SEC * (pre_div + 1) * (pwm_div + 1))
+			- period_rate;
+
+		if (diff < 0) /* period larger than requested */
+			continue;
+		if (diff == 0) { /* bingo */
+			best_pre_div = pre_div;
+			best_pwm_div = pwm_div;
+			break;
+		}
+		if (diff < min_diff) {
+			min_diff = diff;
+			best_pre_div = pre_div;
+			best_pwm_div = pwm_div;
+		}
+	}
+
+	/* config divider values for the closest possible frequency */
+	config_div_and_duty(pwm, best_pre_div, best_pwm_div,
+			    rate, duty_ns, state->enabled);
+
+	return 0;
+}
+
+static int ipq_pwm_get_state(struct pwm_chip *chip, struct pwm_device *pwm,
+			      struct pwm_state *state)
+{
+	struct ipq_pwm_chip *ipq_chip = ipq_pwm_from_chip(chip);
+	unsigned long rate = clk_get_rate(ipq_chip->clk);
+	unsigned int pre_div, pwm_div, hi_dur;
+	u64 effective_div, hi_div;
+	u32 reg0, reg1;
+
+	reg0 = ipq_pwm_reg_read(pwm, IPQ_PWM_REG0);
+	reg1 = ipq_pwm_reg_read(pwm, IPQ_PWM_REG1);
+
+	state->polarity = PWM_POLARITY_NORMAL;
+	state->enabled = reg1 & IPQ_PWM_REG1_ENABLE;
+
+	pwm_div = FIELD_GET(IPQ_PWM_REG0_PWM_DIV, reg0);
+	hi_dur = FIELD_GET(IPQ_PWM_REG0_HI_DURATION, reg0);
+	pre_div = FIELD_GET(IPQ_PWM_REG1_PRE_DIV, reg1);
+
+	/* No overflow here, both pre_div and pwm_div <= 0xffff */
+	effective_div = (u64)(pre_div + 1) * (pwm_div + 1);
+	state->period = DIV64_U64_ROUND_UP(effective_div * NSEC_PER_SEC, rate);
+
+	hi_div = hi_dur * (pre_div + 1);
+	state->duty_cycle = div64_u64(hi_div * NSEC_PER_SEC, rate);
+
+	return 0;
+}
+
+static const struct pwm_ops ipq_pwm_ops = {
+	.apply = ipq_pwm_apply,
+	.get_state = ipq_pwm_get_state,
+};
+
+static int ipq_pwm_probe(struct platform_device *pdev)
+{
+	struct ipq_pwm_chip *pwm;
+	struct device *dev = &pdev->dev;
+	int ret;
+
+	pwm = devm_kzalloc(dev, sizeof(*pwm), GFP_KERNEL);
+	if (!pwm)
+		return -ENOMEM;
+
+	platform_set_drvdata(pdev, pwm);
+
+	pwm->mem = devm_platform_ioremap_resource(pdev, 0);
+	if (IS_ERR(pwm->mem))
+		return dev_err_probe(dev, PTR_ERR(pwm->mem),
+				"regs map failed");
+
+	pwm->clk = devm_clk_get(dev, NULL);
+	if (IS_ERR(pwm->clk))
+		return dev_err_probe(dev, PTR_ERR(pwm->clk),
+				"failed to get clock");
+
+	ret = clk_prepare_enable(pwm->clk);
+	if (ret)
+		return dev_err_probe(dev, ret, "clock enable failed");
+
+	pwm->chip.dev = *dev;
+	pwm->chip.ops = &ipq_pwm_ops;
+	pwm->chip.npwm = 4;
+
+	ret = pwmchip_add(&pwm->chip);
+	if (ret < 0) {
+		dev_err_probe(dev, ret, "pwmchip_add() failed\n");
+		clk_disable_unprepare(pwm->clk);
+	}
+
+	return ret;
+}
+
+static void ipq_pwm_remove(struct platform_device *pdev)
+{
+	struct ipq_pwm_chip *pwm = platform_get_drvdata(pdev);
+
+	pwmchip_remove(&pwm->chip);
+	clk_disable_unprepare(pwm->clk);
+}
+
+static const struct of_device_id pwm_ipq_dt_match[] = {
+	{ .compatible = "qcom,ipq6018-pwm", },
+	{}
+};
+MODULE_DEVICE_TABLE(of, pwm_ipq_dt_match);
+
+static struct platform_driver ipq_pwm_driver = {
+	.driver = {
+		.name = "ipq-pwm",
+		.of_match_table = pwm_ipq_dt_match,
+	},
+	.probe = ipq_pwm_probe,
+	.remove = ipq_pwm_remove,
+};
+
+module_platform_driver(ipq_pwm_driver);
+
+MODULE_LICENSE("Dual BSD/GPL");


### PR DESCRIPTION
Except for USB patches which seem to be already present in kernel 6.12, refactored at times.