### PR TITLE
Fix warnings related to wrong reg format in ipq6018.dtsi

### DIFF
--- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
+++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
@@ -915,6 +915,9 @@
 			/* Single address and size cells. This is required for
 			 * the qca-ssdk driver.
 			 */
+			#address-cells = <1>;
+			#size-cells = <1>;
+
 			reg = <0x3a000000 0x1000000>;
 			switch_access_mode = "local bus";
 			clocks = <&gcc GCC_CMN_12GPLL_AHB_CLK>,
@@ -1316,6 +1319,8 @@
 			/* Single address and size cells. This is required for
 			 * the qca-ssdk driver.
 			 */
+			#address-cells = <1>;
+			#size-cells = <1>;
 			reg = <0x7a00000 0x30000>;
 			uniphy_access_mode = "local bus";
 		};


### PR DESCRIPTION
There is a warning when compiling ipq dts related to wrong reg format of two nodes we added to ipq dtsi.

The default format in dtsi is 2 addr cells and two size cells, however in added nodes it's 1 addr cell and one size cell.

The warning is harmless.