### PR TITLE
DEV-7525: 4addr configuration support in ath12k driver

### DIFF
--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -4501,8 +4501,10 @@ static int ath12k_mac_station_add(struct ath12k *ar,
 
 	ath12k_dbg(ab, ATH12K_DBG_MAC, "Added peer: %pM for VDEV: %d\n",
 		   sta->addr, arvif->vdev_id);
-
-	if (ieee80211_vif_is_mesh(vif)) {
+	/* ------------------------------
+       FORCE WDS / 4-ADDRESS MODE
+       ------------------------------ */
+	//if (ieee80211_vif_is_mesh(vif)) {
 		ret = ath12k_wmi_set_peer_param(ar, sta->addr,
 						arvif->vdev_id,
 						WMI_PEER_USE_4ADDR, 1);
@@ -4511,7 +4513,7 @@ static int ath12k_mac_station_add(struct ath12k *ar,
 				    sta->addr, ret);
 			goto free_peer;
 		}
-	}
+	//}
 
 	ret = ath12k_dp_peer_setup(ar, arvif->vdev_id, sta->addr);
 	if (ret) {


### PR DESCRIPTION
# Description
4addr functionality is currently not supported by the ath12k driver. 
This is core functionality required to pass traffic between Ethernet and wifi interfaces.
I added code to force 4addr functionality.

After changing the ath12k driver, only 4addr mode is working; the link can't be established without 4addr set to on.

# Tests
Establish a link with 4addr and verify traffic is passed between Ethernet and wifi interfaces.
Checklist

# References
DEV-7525