### PR TITLE
DEV-7615: pcie-armada8k: add support for node dependencies

### DIFF
--- a/drivers/ptp/ptp_clockmatrix.c
+++ b/drivers/ptp/ptp_clockmatrix.c
@@ -2518,6 +2518,7 @@ static int idtcm_probe(struct platform_device *pdev)
 	// add the dpll as a hw clock. this is needed to cause the phys and pcies (modems) components
 	// to be called after the dpll initialization by creating clock dependencies in the 
 	// dts file (DEV-6442)
+	msleep(100); // let the ptp clocks settle down before registering the hw clock
 	err = internal_of_clk_add_hw_provider(pdev, idtcm);
 	if (err) {
 		ptp_clock_unregister_all(idtcm);

--- a/drivers/ptp/ptp_clockmatrix.c
+++ b/drivers/ptp/ptp_clockmatrix.c
@@ -2518,7 +2518,7 @@ static int idtcm_probe(struct platform_device *pdev)
 	// add the dpll as a hw clock. this is needed to cause the phys and pcies (modems) components
 	// to be called after the dpll initialization by creating clock dependencies in the 
 	// dts file (DEV-6442)
-	msleep(200); // let the ptp clocks settle down before registering the hw clock
+	msleep(LOCK_TIMEOUT_MS); // let the ptp clocks settle down before registering the hw clock
 	err = internal_of_clk_add_hw_provider(pdev, idtcm);
 	if (err) {
 		ptp_clock_unregister_all(idtcm);

--- a/drivers/ptp/ptp_clockmatrix.c
+++ b/drivers/ptp/ptp_clockmatrix.c
@@ -2518,7 +2518,6 @@ static int idtcm_probe(struct platform_device *pdev)
 	// add the dpll as a hw clock. this is needed to cause the phys and pcies (modems) components
 	// to be called after the dpll initialization by creating clock dependencies in the 
 	// dts file (DEV-6442)
-	msleep(LOCK_TIMEOUT_MS); // let the ptp clocks settle down before registering the hw clock
 	err = internal_of_clk_add_hw_provider(pdev, idtcm);
 	if (err) {
 		ptp_clock_unregister_all(idtcm);

--- a/drivers/ptp/ptp_clockmatrix.c
+++ b/drivers/ptp/ptp_clockmatrix.c
@@ -2518,7 +2518,7 @@ static int idtcm_probe(struct platform_device *pdev)
 	// add the dpll as a hw clock. this is needed to cause the phys and pcies (modems) components
 	// to be called after the dpll initialization by creating clock dependencies in the 
 	// dts file (DEV-6442)
-	msleep(100); // let the ptp clocks settle down before registering the hw clock
+	msleep(200); // let the ptp clocks settle down before registering the hw clock
 	err = internal_of_clk_add_hw_provider(pdev, idtcm);
 	if (err) {
 		ptp_clock_unregister_all(idtcm);


### PR DESCRIPTION
In kernel 6.12, only with `loglevel=0` boot argument, sometimes we have modem FW asserts (ucode 0x4091 means _empty RFs_):
```
"vpp.service","dpdk             [notice]: 0003:01:00.0: Firmware error detected, assert codes FW 0x00004610, UCODE 0x00004091"
```

Armada 8k has 4 x PCI: cp0_pcie0, cp0_pcie1, cp1_pcie0, cp1_pcie1. The issue happens when they are not probed in this order, for example cp0_pcie1, cp1_pcie0, cp1_pcie1 and only then cp0_pcie0. This PR adds support for node dependencies, so the right order can be enforced:
```
&cp0_pcie1 {
    [...]
    depends-on = <&cp0_pcie0>;
};
```

At boot:
```
[   21.784820] armada8k-pcie f2620000.pcie: deferred probe: /cp0/pcie@f2600000 not ready
[   21.785034] armada8k-pcie f4600000.pcie: deferred probe: /cp0/pcie@f2620000 not ready
[   21.785223] armada8k-pcie f4620000.pcie: deferred probe: /cp1/pcie@f4600000 not ready
```