### PR TITLE
VER-113: rtc: rv3028: add RTC_VL_CLR & RTC_VL_BACKUP_SWITCH support

### DIFF
--- a/drivers/rtc/rtc-rv3028.c
+++ b/drivers/rtc/rtc-rv3028.c
@@ -592,8 +592,21 @@ static int rv3028_ioctl(struct device *dev, unsigned int cmd, unsigned long arg)
 		if (ret < 0)
 			return ret;
 
-		status = status & RV3028_STATUS_PORF ? RTC_VL_DATA_INVALID : 0;
+		status = ret & RV3028_STATUS_PORF ? RTC_VL_DATA_INVALID : 0;
+		if (ret & RV3028_STATUS_BSF){
+			status |= RTC_VL_BACKUP_SWITCH;
+		}
 		return put_user(status, (unsigned int __user *)arg);
+	case RTC_VL_CLR:
+		status = regmap_read(rv3028->regmap, RV3028_STATUS, &status);
+		if (ret < 0)
+			return ret;
+		
+		// set RV3028_STATUS_BSF to zero (reset backup switchower indication flag)
+		status &= ~RV3028_STATUS_BSF;
+		ret = regmap_write(rv3028->regmap, RV3028_STATUS, status)
+		if (ret < 0)
+			return ret;
 
 	default:
 		return -ENOIOCTLCMD;


### PR DESCRIPTION
- Update rv3028 driver to report backup switchover indication when using RTC_VL_READ. 
- Add support for RTC_VL_CLR to clear this indication.