### PR TITLE
VER-273: ath12k: fix 4addr multicast packet tx

### DIFF
--- a/drivers/net/wireless/ath/ath12k/core.h
+++ b/drivers/net/wireless/ath/ath12k/core.h
@@ -461,6 +461,8 @@ struct ath12k_sta {
 	struct ath12k_rx_peer_stats *rx_stats;
 	struct ath12k_wbm_tx_stats *wbm_tx_stats;
 	u32 bw_prev;
+	bool use_4addr_set;
+	u16 tcl_metadata;
 };
 
 #define ATH12K_MIN_5G_FREQ 4150

--- a/drivers/net/wireless/ath/ath12k/dp_tx.h
+++ b/drivers/net/wireless/ath/ath12k/dp_tx.h
@@ -17,7 +17,7 @@ struct ath12k_dp_htt_wbm_tx_status {
 
 int ath12k_dp_tx_htt_h2t_ver_req_msg(struct ath12k_base *ab);
 int ath12k_dp_tx(struct ath12k *ar, struct ath12k_vif *arvif,
-		 struct sk_buff *skb);
+		 struct ath12k_sta *arsta, struct sk_buff *skb);
 void ath12k_dp_tx_completion_handler(struct ath12k_base *ab, int ring_id);
 
 int ath12k_dp_tx_htt_h2t_ppdu_stats_req(struct ath12k *ar, u32 mask);

--- a/drivers/net/wireless/ath/ath12k/peer.c
+++ b/drivers/net/wireless/ath/ath12k/peer.c
@@ -266,6 +266,7 @@ int ath12k_peer_create(struct ath12k *ar, struct ath12k_vif *arvif,
 		       struct ath12k_wmi_peer_create_arg *arg)
 {
 	struct ath12k_peer *peer;
+	struct ath12k_sta *arsta;
 	int ret;
 
 	lockdep_assert_held(&ar->conf_mutex);
@@ -333,6 +334,16 @@ int ath12k_peer_create(struct ath12k *ar, struct ath12k_vif *arvif,
 
 	peer->sec_type = HAL_ENCRYPT_TYPE_OPEN;
 	peer->sec_type_grp = HAL_ENCRYPT_TYPE_OPEN;
+
+	if (sta) {
+		arsta = (struct ath12k_sta *)sta->drv_priv;
+		arsta->tcl_metadata |= u32_encode_bits(0, HTT_TCL_META_DATA_TYPE) |
+				       u32_encode_bits(peer->peer_id,
+						  HTT_TCL_META_DATA_PEER_ID);
+
+		/* set HTT extension valid bit to 0 by default */
+		arsta->tcl_metadata &= ~HTT_TCL_META_DATA_VALID_HTT;
+	}
 
 	ar->num_peers++;
 


### PR DESCRIPTION
This patch forward-ports e20cfa3b62aeb1b5fc5ffa86a007af97f9954767 from ath11k to ath12k. Ping between AP and station now succeeds.