### PR TITLE
TG-332: Add Github action for building Linux kernel #2 (Fix build issue remove ipq6018-siklu-ctu-100.dtb from Makefile)

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -17,7 +17,6 @@ dtb-$(CONFIG_ARCH_QCOM)	+= ipq5332-rdp442.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= ipq5332-rdp468.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= ipq5332-rdp474.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= ipq6018-cp01-c1.dtb
-dtb-$(CONFIG_ARCH_QCOM)	+= ipq6018-siklu-ctu-100.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= ipq8074-hk01.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= ipq8074-hk10-c1.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= ipq8074-hk10-c2.dtb


### PR DESCRIPTION
Fix build issue i.e. removed ipq6018-siklu-ctu-100.dtb from Makefile.
Build got passed last time due to cache : here is original pull request https://github.com/siklu/linux/pull/61

Failure:
https://github.com/siklu/linux/actions/runs/19708155136/job/56461156967