### PR TITLE
VER-845: ath12k: fix invalid TX power level reporting

### DIFF
--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -5465,7 +5465,7 @@ send_tx_power:
 		goto err_fallback;
 	}
 
-	*dbm = ar->chan_tx_pwr;
+	*dbm = txpwr;
 	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "txpower fetched from firmware %d dBm\n",
 		   *dbm);
 	return 0;

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -5402,6 +5402,7 @@ int ath12k_mac_op_get_txpower(struct ieee80211_hw *hw,
 	struct ath12k_base *ab;
 	struct ath12k *ar;
 	int ret;
+	s16 txpwr;
 
 	/* Final Tx power is minimum of Target Power, CTL power, Regulatory
 	 * Power, PSD EIRP Power. We just know the Regulatory power from the
@@ -5454,6 +5455,16 @@ int ath12k_mac_op_get_txpower(struct ieee80211_hw *hw,
 	ath12k_fw_stats_reset(ar);
 
 send_tx_power:
+	txpwr = ar->chan_tx_pwr;
+	/* Check whether the tx power value is valid before reporting to mac80211. */
+	if (txpwr > ATH12K_TX_POWER_MAX_VAL ||
+	    txpwr < ATH12K_TX_POWER_MIN_VAL) {
+		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
+			   "invalid txpower fetched from firmware %d dBm\n",
+			   txpwr);
+		goto err_fallback;
+	}
+
 	*dbm = ar->chan_tx_pwr;
 	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "txpower fetched from firmware %d dBm\n",
 		   *dbm);


### PR DESCRIPTION
Station running WLAN.WBE.1.5-01651-QCAHKSWPL_SILICONZ-1 firmware always reports -4 dBm as the TX power level, which is an invalid value. This issue does not occur on AP. Use the same validation as in `ath12k_mac_op_sta_set_txpwr` and go to the existing fallback for invalid values.

Debug logs:
```
# Station
ath12k_wifi7_pci 0002:01:00.0: invalid txpower fetched from firmware -4 dBm
ath12k_wifi7_pci 0002:01:00.0: txpower from firmware NaN, reported 24 dBm

# AP
ath12k_wifi7_pci 0002:01:00.0: txpower fetched from firmware 22 dBm
```