### PR TITLE
VER-847: ath12k: peer lookup failure during STA stats retrieval (tentative fix)

### DIFF
--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -5431,7 +5431,7 @@ int ath12k_mac_op_get_txpower(struct ieee80211_hw *hw,
 					 ar->last_tx_power_update))
 		goto send_tx_power;
 
-	params.pdev_id = ar->pdev->pdev_id;
+	params.pdev_id = ath12k_mac_get_target_pdev_id(ar);
 	params.vdev_id = arvif->vdev_id;
 	params.stats_id = WMI_REQUEST_PDEV_STAT;
 	ret = ath12k_mac_get_fw_stats(ar, &params);
@@ -13466,7 +13466,7 @@ void ath12k_mac_op_sta_statistics(struct ieee80211_hw *hw,
 	/* TODO: Use real NF instead of default one. */
 	signal = rate_info.rssi_comb;
 
-	params.pdev_id = ar->pdev->pdev_id;
+	params.pdev_id = ath12k_mac_get_target_pdev_id(ar);
 	params.vdev_id = 0;
 	params.stats_id = WMI_REQUEST_VDEV_STAT;
 
@@ -13594,7 +13594,7 @@ void ath12k_mac_op_link_sta_statistics(struct ieee80211_hw *hw,
 	spin_unlock_bh(&ar->ab->dp->dp_lock);
 
 	if (!signal && ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA) {
-		params.pdev_id = ar->pdev->pdev_id;
+		params.pdev_id = ath12k_mac_get_target_pdev_id(ar);
 		params.vdev_id = 0;
 		params.stats_id = WMI_REQUEST_VDEV_STAT;
 


### PR DESCRIPTION
This PR cherry-picks the latest advancements of upstream ath12k driver. They address issues with ath12k station statistics requests (trace shows problem with `ath12k_mac_op_sta_statistics`), so they may help resolve the issue we are seeing.

However, we've seen the `failed to find the peer with peer_id` error in the past, caused by https://github.com/torvalds/linux/commit/981050b918fc4c36e0ef3bd7392b39d7304ef09b and also reported here https://bugzilla.kernel.org/show_bug.cgi?id=221039 . We reverted it in the past, and if the issue still reproduces after this PR we might need to revert it again.

Qualcomm's driver changes the log level of this error to debug in https://git.codelinaro.org/clo/qsdk/oss/src/mac80211/wlan-open/-/commit/c8f276e7615d3156e07e1ed217ca96a2484ada09 

```
[ 1538.267889] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1549.565115] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.022450] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.081428] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.244533] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.255377] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.445195] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.456415] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.642817] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1550.653841] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1551.041720] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1551.053444] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1551.260004] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1551.270678] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1566.278552] ath12k_wifi7_pci 0002:01:00.0: dp_tx: failed to find the peer with peer_id 3
[ 1574.911836] rcu: INFO: rcu_sched self-detected stall on CPU
[ 1574.917441] rcu:     1-....: (209637 ticks this GP) idle=819c/1/0x4000000000000000 softirq=11455/11457 fqs=105024
[ 1574.927491] rcu:     (t=210121 jiffies g=13209 q=1984 ncpus=4)
[ 1574.933091] CPU: 1 UID: 0 PID: 567 Comm: FR2Agent0 Tainted: G           O        6.18.0-yocto-standard-g9e46c59c3a0c #1 NONE 
[ 1574.933097] Tainted: [O]=OOT_MODULE
[ 1574.933098] Hardware name: Siklu N366 (DT)
[ 1574.933100] pstate: 20000005 (nzCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[ 1574.933104] pc : ath12k_dp_link_peer_find_by_addr+0xe8/0x13c [ath12k]
[ 1574.933121] lr : ath12k_dp_link_peer_find_by_addr+0x11c/0x13c [ath12k]
[ 1574.933135] sp : ffff80008397b4a0
[ 1574.933136] x29: ffff80008397b4a0 x28: ffff80008397b720 x27: ffff00003ac0d000
[ 1574.933142] x26: ffff00002be01e11 x25: ffff00002be01c00 x24: ffff000000de7840
[ 1574.933146] x23: 0000000000000000 x22: ffff00003ad68f40 x21: ffff00003ac0dd30
[ 1574.933151] x20: ffff00002be01e10 x19: ff2001f4fe1802c3 x18: 0000000000000000
[ 1574.933156] x17: 0000000000000000 x16: 0000000000000000 x15: 0000ffff18035440
[ 1574.933160] x14: ffff800080d0e0a8 x13: 0000000000000060 x12: ffff800080c35d68
[ 1574.933165] x11: ffffffffffffffff x10: ffff800080c35c40 x9 : ffffffffffffffff
[ 1574.933170] x8 : ffff8000811ab310 x7 : 0000000011babbbe x6 : 00007dffc0bf65a0
[ 1574.933175] x5 : 3e54fff200000000 x4 : 0000000011babbfc x3 : 8c12982400000000
[ 1574.933179] x2 : 0000000000000002 x1 : ffff00003ac0dd34 x0 : 0000000000000001
[ 1574.933184] Call trace:
[ 1574.933186]  ath12k_dp_link_peer_find_by_addr+0xe8/0x13c [ath12k] (P)
[ 1574.933200]  ath12k_dp_link_peer_get_sta_rate_info_stats+0x60/0x160 [ath12k]
[ 1574.933214]  ath12k_mac_op_sta_statistics+0xa8/0x3d0 [ath12k]
[ 1574.933228]  sta_set_sinfo+0x260/0xe44
[ 1574.933239]  ieee80211_get_station+0x34/0x7c
[ 1574.933243]  nl80211_get_station+0xbc/0x254
[ 1574.933249]  genl_family_rcv_msg_doit.isra.0+0xb8/0x11c
[ 1574.933254]  genl_rcv_msg+0x1b8/0x238
[ 1574.933258]  netlink_rcv_skb+0x54/0x128
[ 1574.933262]  genl_rcv+0x34/0x48
[ 1574.933265]  netlink_unicast+0x1dc/0x2d4
[ 1574.933272]  netlink_sendmsg+0x168/0x39c
[ 1574.933277]  ____sys_sendmsg+0x20c/0x234
[ 1574.933283]  ___sys_sendmsg+0x7c/0xc0
[ 1574.933287]  __sys_sendmsg+0x70/0xd4
[ 1574.933292]  __arm64_sys_sendmsg+0x20/0x28
[ 1574.933297]  invoke_syscall.constprop.0+0x48/0xc8
[ 1574.933304]  do_el0_svc+0x3c/0xb8
[ 1574.933309]  el0_svc+0x3c/0x150
[ 1574.933315]  el0t_64_sync_handler+0xc8/0xdc
[ 1574.933320]  el0t_64_sync+0x170/0x174
```