### PR TITLE
VER-863: ath12k: add support for split-PHY for QCN9274

### DIFF
--- a/drivers/net/wireless/ath/ath12k/core.c
+++ b/drivers/net/wireless/ath/ath12k/core.c
@@ -34,6 +34,10 @@ module_param_named(ftm_mode, ath12k_ftm_mode, bool, 0444);
 MODULE_PARM_DESC(ftm_mode, "Boots up in factory test mode");
 EXPORT_SYMBOL(ath12k_ftm_mode);
 
+bool ath12k_split_phy_mode;
+module_param_named(split_phy_mode, ath12k_split_phy_mode, bool, 0444);
+MODULE_PARM_DESC(split_phy_mode, "Enable split PHY mode (disable MLO, expose each radio as separate wiphy)");
+
 /* protected with ath12k_hw_group_mutex */
 static struct list_head ath12k_hw_group_list = LIST_HEAD_INIT(ath12k_hw_group_list);
 
@@ -2144,6 +2148,14 @@ void ath12k_core_hw_group_set_mlo_capable(struct ath12k_hw_group *ag)
 
 	if (ath12k_ftm_mode)
 		return;
+
+	if (ath12k_split_phy_mode) {
+		ag->mlo_capable = false;
+		ab = ag->ab[0];
+		if (ab)
+			ath12k_info(ab, "split PHY mode enabled: MLO disabled, each radio exposed as separate wiphy\n");
+		return;
+	}
 
 	lockdep_assert_held(&ag->mutex);
 

--- a/drivers/net/wireless/ath/ath12k/core.c
+++ b/drivers/net/wireless/ath/ath12k/core.c
@@ -38,6 +38,15 @@ bool ath12k_split_phy_mode;
 module_param_named(split_phy_mode, ath12k_split_phy_mode, bool, 0444);
 MODULE_PARM_DESC(split_phy_mode, "Enable split PHY mode (disable MLO, expose each radio as separate wiphy)");
 
+/*
+ * Force dual-mac firmware loading regardless of OTP board ID.
+ * Required for some boards (like 8devices Noni) where the OTP doesn't
+ * have the dual-mac bit set but the hardware supports dual-radio operation.
+ */
+bool ath12k_force_dualmac;
+module_param_named(force_dualmac, ath12k_force_dualmac, bool, 0444);
+MODULE_PARM_DESC(force_dualmac, "Force loading dual-mac firmware (required for some dual-radio boards)");
+
 /* protected with ath12k_hw_group_mutex */
 static struct list_head ath12k_hw_group_list = LIST_HEAD_INIT(ath12k_hw_group_list);
 

--- a/drivers/net/wireless/ath/ath12k/core.h
+++ b/drivers/net/wireless/ath/ath12k/core.h
@@ -1430,4 +1430,8 @@ static inline struct ath12k *ath12k_pdev_dp_to_ar(struct ath12k_pdev_dp *dp)
 {
 	return container_of(dp, struct ath12k, dp);
 }
+
+/* Module parameters */
+extern bool ath12k_split_phy_mode;
+
 #endif /* _CORE_H_ */

--- a/drivers/net/wireless/ath/ath12k/core.h
+++ b/drivers/net/wireless/ath/ath12k/core.h
@@ -1433,5 +1433,6 @@ static inline struct ath12k *ath12k_pdev_dp_to_ar(struct ath12k_pdev_dp *dp)
 
 /* Module parameters */
 extern bool ath12k_split_phy_mode;
+extern bool ath12k_force_dualmac;
 
 #endif /* _CORE_H_ */

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -8443,9 +8443,7 @@ static void ath12k_mac_setup_ht_vht_cap(struct ath12k *ar,
 						    rate_cap_rx_chainmask);
 	}
 
-	if (cap->supported_bands & WMI_HOST_WLAN_5GHZ_CAP &&
-	    (ar->ab->hw_params->single_pdev_only ||
-	     !ar->supports_6ghz)) {
+	if (cap->supported_bands & WMI_HOST_WLAN_5GHZ_CAP) {
 		band = &ar->mac.sbands[NL80211_BAND_5GHZ];
 		ht_cap = cap->band[NL80211_BAND_5GHZ].ht_cap_info;
 		if (ht_cap_info)

--- a/drivers/net/wireless/ath/ath12k/mhi.c
+++ b/drivers/net/wireless/ath/ath12k/mhi.c
@@ -18,6 +18,9 @@
 #define OTP_VALID_DUALMAC_BOARD_ID_MASK		0x1000
 #define MHI_CB_INVALID	0xff
 
+/* Force dual-mac firmware loading (from core.c module parameter) */
+extern bool ath12k_force_dualmac;
+
 void ath12k_mhi_set_mhictrl_reset(struct ath12k_base *ab)
 {
 	u32 val;
@@ -203,7 +206,11 @@ int ath12k_mhi_register(struct ath12k_pci *ab_pci)
 	mhi_ctrl->reg_len = ab->mem_len;
 	mhi_ctrl->rddm_size = ab->hw_params->rddm_size;
 
-	if (ab->hw_params->otp_board_id_register) {
+	/* Check for force_dualmac module parameter first */
+	if (ath12k_force_dualmac) {
+		dualmac = true;
+		ath12k_info(ab, "force_dualmac enabled: loading dual-mac firmware\n");
+	} else if (ab->hw_params->otp_board_id_register) {
 		board_id =
 			ath12k_pci_read32(ab, ab->hw_params->otp_board_id_register);
 		board_id = u32_get_bits(board_id, OTP_BOARD_ID_MASK);

--- a/drivers/net/wireless/ath/ath12k/wmi.c
+++ b/drivers/net/wireless/ath/ath12k/wmi.c
@@ -2814,6 +2814,9 @@ int ath12k_wmi_send_scan_chan_list_cmd(struct ath12k *ar,
 		max_chan_limit = (wmi->wmi_ab->max_msg_len[ar->pdev_idx] - len) /
 			sizeof(*chan_info);
 
+		if (max_chan_limit > WMI_MAX_NUM_CHAN_PER_WMI_CMD)
+			max_chan_limit = WMI_MAX_NUM_CHAN_PER_WMI_CMD;
+
 		num_send_chans = min3(arg->nallchans, max_chan_limit,
 				      ATH12K_WMI_MAX_NUM_CHAN_PER_CMD);
 

--- a/drivers/net/wireless/ath/ath12k/wmi.h
+++ b/drivers/net/wireless/ath/ath12k/wmi.h
@@ -4010,6 +4010,8 @@ struct wmi_stop_scan_cmd {
 	__le32 pdev_id;
 } __packed;
 
+#define WMI_MAX_NUM_CHAN_PER_WMI_CMD	58
+
 struct ath12k_wmi_scan_chan_list_arg {
 	struct list_head list;
 	u32 pdev_id;


### PR DESCRIPTION
This PR cherry-picks the support for split-PHY mode, mainly adding two parameters to the ath12k driver:
1. split_phy_mode - disable MLO, expose each radio as separate wiphy
2. force_dualmac - force loading dual-mac firmware (required for some dual-radio boards)