### PR TITLE
TG-997: sfp: fix module not detected on insert

### DIFF
--- a/drivers/net/phy/sfp.c
+++ b/drivers/net/phy/sfp.c
@@ -593,6 +593,8 @@ static const struct sfp_quirk *sfp_lookup_quirk(const struct sfp_eeprom_id *id)
 	return NULL;
 }
 
+static int sfp_read(struct sfp *sfp, bool a2, u8 addr, void *buf, size_t len);
+
 static unsigned int sfp_gpio_get_state(struct sfp *sfp)
 {
 	unsigned int i, state, v;
@@ -616,15 +618,26 @@ static unsigned int sff_gpio_get_state(struct sfp *sfp)
 
 /* Detect module presence via I2C when MODDEF0 GPIO is not available.
  * Probes the SFP EEPROM at I2C address 0x50 to determine if a module
- * is inserted.
+ * is inserted. Retries on transient I2C errors to avoid false removal
+ * events, but exits immediately on NACK (-ENXIO) which means no module.
  */
 static unsigned int sfp_i2c_get_state(struct sfp *sfp)
 {
 	unsigned int state = sfp_gpio_get_state(sfp);
+	int retries = 3;
 	u8 val;
+	int ret;
 
-	if (sfp->read(sfp, false, 0, &val, sizeof(val)) == sizeof(val))
-		state |= SFP_F_PRESENT;
+	while (retries--) {
+		ret = sfp_read(sfp, false, 0, &val, sizeof(val));
+		if (ret == sizeof(val)) {
+			state |= SFP_F_PRESENT;
+			break;
+		}
+		/* NACK means no device present, no point retrying */
+		if (ret == -ENXIO)
+			break;
+	}
 
 	return state;
 }

--- a/drivers/net/phy/sfp.c
+++ b/drivers/net/phy/sfp.c
@@ -596,9 +596,7 @@ static const struct sfp_quirk *sfp_lookup_quirk(const struct sfp_eeprom_id *id)
 static unsigned int sfp_gpio_get_state(struct sfp *sfp)
 {
 	unsigned int i, state, v;
-	int repeat = 10;
 
-again:
 	for (i = state = 0; i < GPIO_MAX; i++) {
 		if (gpio_flags[i] != GPIOD_IN || !sfp->gpio[i])
 			continue;
@@ -606,15 +604,6 @@ again:
 		v = gpiod_get_value_cansleep(sfp->gpio[i]);
 		if (v)
 			state |= BIT(i);
-	}
-
-	/* Trivial debounce. When no state change is detected, wait for up to
-	 * a limited bound time interval for the signal state to settle.
-	 */
-	if (state == sfp->state && repeat > 0) {
-		udelay(10);
-		repeat--;
-		goto again;
 	}
 
 	return state;

--- a/drivers/net/phy/sfp.c
+++ b/drivers/net/phy/sfp.c
@@ -248,6 +248,7 @@ struct sfp {
 	int gpio_irq[GPIO_MAX];
 
 	bool need_poll;
+	unsigned int i2c_detect_retries;
 
 	/* Access rules:
 	 * state_hw_drive: st_mutex held
@@ -616,27 +617,26 @@ static unsigned int sff_gpio_get_state(struct sfp *sfp)
 	return sfp_gpio_get_state(sfp) | SFP_F_PRESENT;
 }
 
+#define N_I2C_DETECT_RETRIES	3
+
 /* Detect module presence via I2C when MODDEF0 GPIO is not available.
- * Probes the SFP EEPROM at I2C address 0x50 to determine if a module
- * is inserted. Retries on transient I2C errors to avoid false removal
- * events, but exits immediately on NACK (-ENXIO) which means no module.
+ * Performs a single I2C read per poll (every 100ms) and uses a debounce
+ * counter across consecutive polls: the module is reported as removed
+ * only after N_I2C_DETECT_RETRIES consecutive failures. A single
+ * successful read resets the counter and confirms presence.
  */
 static unsigned int sfp_i2c_get_state(struct sfp *sfp)
 {
 	unsigned int state = sfp_gpio_get_state(sfp);
-	int retries = 3;
 	u8 val;
-	int ret;
 
-	while (retries--) {
-		ret = sfp_read(sfp, false, 0, &val, sizeof(val));
-		if (ret == sizeof(val)) {
-			state |= SFP_F_PRESENT;
-			break;
-		}
-		/* NACK means no device present, no point retrying */
-		if (ret == -ENXIO)
-			break;
+	if (sfp_read(sfp, false, 0, &val, sizeof(val)) == sizeof(val)) {
+		sfp->i2c_detect_retries = N_I2C_DETECT_RETRIES;
+		state |= SFP_F_PRESENT;
+	} else if (sfp->i2c_detect_retries) {
+		/* Not yet exhausted retries, keep reporting present */
+		sfp->i2c_detect_retries--;
+		state |= SFP_F_PRESENT;
 	}
 
 	return state;

--- a/drivers/net/phy/sfp.c
+++ b/drivers/net/phy/sfp.c
@@ -614,6 +614,21 @@ static unsigned int sff_gpio_get_state(struct sfp *sfp)
 	return sfp_gpio_get_state(sfp) | SFP_F_PRESENT;
 }
 
+/* Detect module presence via I2C when MODDEF0 GPIO is not available.
+ * Probes the SFP EEPROM at I2C address 0x50 to determine if a module
+ * is inserted.
+ */
+static unsigned int sfp_i2c_get_state(struct sfp *sfp)
+{
+	unsigned int state = sfp_gpio_get_state(sfp);
+	u8 val;
+
+	if (sfp->read(sfp, false, 0, &val, sizeof(val)) == sizeof(val))
+		state |= SFP_F_PRESENT;
+
+	return state;
+}
+
 /**
  * simulate_pull_up - simulate a pull-up on a GPIO
  * @desc: GPIO descriptor
@@ -793,6 +808,8 @@ static int sfp_i2c_configure(struct sfp *sfp, struct i2c_adapter *i2c)
 		sfp->i2c = NULL;
 		return -EINVAL;
 	}
+
+	sfp->i2c_block_size = sfp->i2c_max_block_size;
 
 	return 0;
 }
@@ -3130,9 +3147,13 @@ static int sfp_probe(struct platform_device *pdev)
 	sfp->get_state = sfp_gpio_get_state;
 	sfp->set_state = sfp_gpio_set_state;
 
-	/* Modules that have no detect signal are always present */
-	if (!(sfp->gpio[GPIO_MODDEF0]))
-		sfp->get_state = sff_gpio_get_state;
+	/* Modules that have no detect signal use I2C probing for presence
+	 * detection, which allows hotplug to work without a MODDEF0 GPIO.
+	 */
+	if (!(sfp->gpio[GPIO_MODDEF0])) {
+		sfp->get_state = sfp_i2c_get_state;
+		sfp->need_poll = true;
+	}
 
 	device_property_read_u32(&pdev->dev, "maximum-power-milliwatt",
 				 &sfp->max_power_mW);


### PR DESCRIPTION
N366 HW does not have pull-up resistors for the GPIO input lines, which is the reason why https://github.com/siklu/devices/pull/2247 removed them from DTS. Without a pull-up, the lines float when no module is present, which gives unreliable readings (could randomly read low/"present" or high/"absent").

Without MODDEF0 GPIO (signaling presence), sff_gpio_get_state always reports SFP_F_PRESENT. At boot, if no module exists, the driver enters SFP_MOD_ERROR after failed probes. When a module is later inserted, sfp_check_state sees no change (still PRESENT), so no SFP_E_INSERT event is fired - hotplug is dead.

This PR creates a new get_state function that probes the SFP EEPROM at I2C address 0x50 to detect module presence, and enable polling so hotplug transitions are detected.

It also reverts 03e8933b8530841be9e1f64fc4dd2a5b182c884c because it is dead code, now that no input GPIOs exist.