### PR TITLE
TG-622: rtc: pcf8523 disable CLKOUT and BLD to reduce battery drain

### DIFF
--- a/drivers/rtc/rtc-pcf8523.c
+++ b/drivers/rtc/rtc-pcf8523.c
@@ -479,15 +479,25 @@ static int pcf8523_probe(struct i2c_client *client)
 	set_bit(RTC_FEATURE_ALARM_RES_MINUTE, rtc->features);
 	clear_bit(RTC_FEATURE_UPDATE_INTERRUPT, rtc->features);
 
+	/* disable CLKOUT */
+	err = regmap_write(pcf8523->regmap, PCF8523_TMR_CLKOUT_CTRL, 0x38);
+	if (err < 0)
+		return err;
+
+	/* battery switch-over function is enabled in standard mode;
+	 * battery low detection function is disabled
+	 */
+	err = regmap_update_bits(pcf8523->regmap, PCF8523_REG_CONTROL3,
+				 PCF8523_CONTROL3_PM,
+				 FIELD_PREP(PCF8523_CONTROL3_PM, 0x4));
+	if (err < 0)
+		return err;
+
 	if (client->irq > 0) {
 		unsigned long irqflags = IRQF_TRIGGER_LOW;
 
 		if (dev_fwnode(&client->dev))
 			irqflags = 0;
-
-		err = regmap_write(pcf8523->regmap, PCF8523_TMR_CLKOUT_CTRL, 0x38);
-		if (err < 0)
-			return err;
 
 		err = devm_request_threaded_irq(&client->dev, client->irq,
 						NULL, pcf8523_irq,

--- a/drivers/rtc/rtc-pcf8523.c
+++ b/drivers/rtc/rtc-pcf8523.c
@@ -22,6 +22,7 @@
 
 #define PCF8523_REG_CONTROL3 0x02
 #define PCF8523_CONTROL3_PM  GENMASK(7, 5)
+#define PCF8523_PM_STANDARD  0x4
 #define PCF8523_PM_STANDBY   0x7
 #define PCF8523_CONTROL3_BLF BIT(2) /* battery low bit, read-only */
 #define PCF8523_CONTROL3_BSF BIT(3)
@@ -46,6 +47,8 @@
 #define PCF8523_OFFSET_MODE BIT(7)
 
 #define PCF8523_TMR_CLKOUT_CTRL 0x0f
+#define PCF8523_TMR_CLKOUT_COF	GENMASK(5, 3)
+#define PCF8523_COF_DISABLED	0x7
 
 struct pcf8523 {
 	struct rtc_device *rtc;
@@ -480,7 +483,8 @@ static int pcf8523_probe(struct i2c_client *client)
 	clear_bit(RTC_FEATURE_UPDATE_INTERRUPT, rtc->features);
 
 	/* disable CLKOUT */
-	err = regmap_write(pcf8523->regmap, PCF8523_TMR_CLKOUT_CTRL, 0x38);
+	err = regmap_write(pcf8523->regmap, PCF8523_TMR_CLKOUT_CTRL,
+			   FIELD_PREP(PCF8523_TMR_CLKOUT_COF, PCF8523_COF_DISABLED));
 	if (err < 0)
 		return err;
 
@@ -489,7 +493,7 @@ static int pcf8523_probe(struct i2c_client *client)
 	 */
 	err = regmap_update_bits(pcf8523->regmap, PCF8523_REG_CONTROL3,
 				 PCF8523_CONTROL3_PM,
-				 FIELD_PREP(PCF8523_CONTROL3_PM, 0x4));
+				 FIELD_PREP(PCF8523_CONTROL3_PM, PCF8523_PM_STANDARD));
 	if (err < 0)
 		return err;
 


### PR DESCRIPTION
This PR disables the CLKOUT 32.768kHz signal and battery low detection to reduce RTC's battery drain. The same configuration is applied on EH8010.

Tested with I2C register read, addresses 0x2 (PCF8523_REG_CONTROL3) and 0xF (PCF8523_TMR_CLKOUT_CTRL)
```
root@terragraph:~# i2cdump -f -y 0 0x68
No size specified (using byte-data access)
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f    0123456789abcdef
00: 00 00 80 08 51 10 26 04 03 26 80 80 80 80 00 38    ..??Q?&??&????.8
```