### PR TITLE
VER-895: wifi: ath12k: fix dp_peer stale entry on station removal failure

### DIFF
--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7755,6 +7755,17 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 				goto peer_delete;
 			if (old_state == IEEE80211_STA_NONE &&
 			    new_state == IEEE80211_STA_NOTEXIST)
+				/* Teardown must not propagate failure to
+				 * mac80211 — returning an error here triggers
+				 * a WARNING in __sta_info_destroy_part2 and
+				 * leaves the station state machine stuck.
+				 * The typical failure is a WMI peer-delete
+				 * timeout (FW never sends HTT peer_unmap);
+				 * the peer is already gone from the driver's
+				 * perspective.  Jump to peer_cleanup so that
+				 * ath12k_dp_peer_delete() frees the dp_peer
+				 * and ret is set to 0.
+				 */
 				goto peer_cleanup;
 
 			goto exit;

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7753,11 +7753,8 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			if (old_state == IEEE80211_STA_NOTEXIST &&
 			    new_state == IEEE80211_STA_NONE)
 				goto peer_delete;
-			else if (old_state == IEEE80211_STA_NONE &&
-				 new_state == IEEE80211_STA_NOTEXIST) {
-				goto peer_clean;
-			} else
-				goto exit;
+			else 
+				goto peer_cleanup;
 		}
 	}
 
@@ -7779,7 +7776,7 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			prev_ab = ab;
 		}
 	}
-peer_clean:
+peer_cleanup:
 	/* IEEE80211_STA_NONE -> IEEE80211_STA_NOTEXIST:
 	 * Remove the station from driver (handle ML sta here since that
 	 * needs special handling. Normal sta will be handled in generic

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7756,10 +7756,15 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			else if (old_state == IEEE80211_STA_NONE &&
 				 new_state == IEEE80211_STA_NOTEXIST) {
 				/* Teardown must not fail from mac80211's
-				 * perspective. Clean up the ath12k_dp_peer
-				 * that won't be reached by the normal success
-				 * path, and tell mac80211 we succeeded.
+				 * perspective. Clean up any MLO-specific
+				 * state that won't be reached by the normal
+				 * success path, then clean up the
+				 * ath12k_dp_peer and tell mac80211 we
+				 * succeeded.
 				 */
+				if (sta->mlo)
+					ath12k_mac_ml_station_remove(hw, vif, sta);
+
 				ret = 0;
 				goto peer_delete;
 			} else

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7753,8 +7753,11 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			if (old_state == IEEE80211_STA_NOTEXIST &&
 			    new_state == IEEE80211_STA_NONE)
 				goto peer_delete;
-			else 
+			if (old_state == IEEE80211_STA_NONE &&
+			    new_state == IEEE80211_STA_NOTEXIST)
 				goto peer_cleanup;
+
+			goto exit;
 		}
 	}
 

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -14983,7 +14983,7 @@ int ath12k_mac_register(struct ath12k_hw_group *ag)
 	struct ath12k_hw *ah;
 	int i;
 	int ret;
-    printk(KERN_INFO "ath12k: Gadi 27-4 (test)\n");
+
 	for (i = 0; i < ag->num_hw; i++) {
 		ah = ath12k_ag_to_ah(ag, i);
 

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7756,7 +7756,7 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			if (old_state == IEEE80211_STA_NONE &&
 			    new_state == IEEE80211_STA_NOTEXIST)
 				/* Teardown must not propagate failure to
-				 * mac80211 — returning an error here triggers
+				 * mac80211 -- returning an error here triggers
 				 * a WARNING in __sta_info_destroy_part2 and
 				 * leaves the station state machine stuck.
 				 * The typical failure is a WMI peer-delete

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7758,15 +7758,20 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 				/* Teardown must not fail from mac80211's
 				 * perspective. Clean up any MLO-specific
 				 * state that won't be reached by the normal
-				 * success path, then clean up the
+				 * success path, then clean up only the
 				 * ath12k_dp_peer and tell mac80211 we
-				 * succeeded.
+				 * succeeded. Do not jump to peer_delete
+				 * after ml_station_remove(), because that
+				 * path can later reach ml_peer_id_clear
+				 * after ahsta->ml_peer_id has already been
+				 * invalidated.
 				 */
 				if (sta->mlo)
 					ath12k_mac_ml_station_remove(ahvif, ahsta);
 
+				ath12k_dp_peer_delete(arvif->ar, arsta->addr);
 				ret = 0;
-				goto peer_delete;
+				goto exit;
 			} else
 				goto exit;
 		}

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7760,10 +7760,8 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 				 * that won't be reached by the normal success
 				 * path, and tell mac80211 we succeeded.
 				 */
-				ath12k_dp_peer_delete(&ah->dp_hw,
-						      sta->addr, sta);
 				ret = 0;
-				goto exit;
+				goto peer_delete;
 			} else
 				goto exit;
 		}
@@ -14985,7 +14983,7 @@ int ath12k_mac_register(struct ath12k_hw_group *ag)
 	struct ath12k_hw *ah;
 	int i;
 	int ret;
-
+    printk(KERN_INFO "ath12k: Gadi 27-4 (test)\n");
 	for (i = 0; i < ag->num_hw; i++) {
 		ah = ath12k_ag_to_ah(ag, i);
 

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7753,7 +7753,18 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			if (old_state == IEEE80211_STA_NOTEXIST &&
 			    new_state == IEEE80211_STA_NONE)
 				goto peer_delete;
-			else
+			else if (old_state == IEEE80211_STA_NONE &&
+				 new_state == IEEE80211_STA_NOTEXIST) {
+				/* Teardown must not fail from mac80211's
+				 * perspective. Clean up the ath12k_dp_peer
+				 * that won't be reached by the normal success
+				 * path, and tell mac80211 we succeeded.
+				 */
+				ath12k_dp_peer_delete(&ah->dp_hw,
+						      sta->addr, sta);
+				ret = 0;
+				goto exit;
+			} else
 				goto exit;
 		}
 	}

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7763,7 +7763,7 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 				 * succeeded.
 				 */
 				if (sta->mlo)
-					ath12k_mac_ml_station_remove(hw, vif, sta);
+					ath12k_mac_ml_station_remove(ahvif, ahsta);
 
 				ret = 0;
 				goto peer_delete;

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -7755,23 +7755,7 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 				goto peer_delete;
 			else if (old_state == IEEE80211_STA_NONE &&
 				 new_state == IEEE80211_STA_NOTEXIST) {
-				/* Teardown must not fail from mac80211's
-				 * perspective. Clean up any MLO-specific
-				 * state that won't be reached by the normal
-				 * success path, then clean up only the
-				 * ath12k_dp_peer and tell mac80211 we
-				 * succeeded. Do not jump to peer_delete
-				 * after ml_station_remove(), because that
-				 * path can later reach ml_peer_id_clear
-				 * after ahsta->ml_peer_id has already been
-				 * invalidated.
-				 */
-				if (sta->mlo)
-					ath12k_mac_ml_station_remove(ahvif, ahsta);
-
-				ath12k_dp_peer_delete(arvif->ar, arsta->addr);
-				ret = 0;
-				goto exit;
+				goto peer_clean;
 			} else
 				goto exit;
 		}
@@ -7795,6 +7779,7 @@ int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
 			prev_ab = ab;
 		}
 	}
+peer_clean:
 	/* IEEE80211_STA_NONE -> IEEE80211_STA_NOTEXIST:
 	 * Remove the station from driver (handle ML sta here since that
 	 * needs special handling. Normal sta will be handled in generic


### PR DESCRIPTION
wifi: ath12k: fix dp_peer stale entry on station removal failure

When stopping hostapd, mac80211 triggers a state transition for stations
from IEEE80211_STA_NONE to IEEE80211_STA_NOTEXIST.

In ath12k_mac_op_sta_state, if the WMI command to delete a peer fails 
(e.g., due to a firmware timeout), the current error handler jumps 
directly to the exit label. This skips the second stage of cleanup: 
ath12k_dp_peer_delete().

As a result, an orphaned ath12k_dp_peer entry remains in dp_peers_list.
When the station tries to reconnect, ath12k_dp_peer_create() finds the 
stale entry and returns -EEXIST, leading to the error:
"unable to create ath12k_dp_peer for sta".

Fix this by adding a peer_cleanup label that ensures ath12k_dp_peer_delete()
is called even if the firmware-side removal failed, as mac80211 will
remove the station regardless.

Tests: Automation test- 100 times of stop/start hostapd (by changing the RF configuration)