### PR TITLE
VER-887: wifi: ath12k: handle XRETRY peer kickout as beacon loss for station mode

### DIFF
--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -15012,7 +15012,7 @@ int ath12k_mac_register(struct ath12k_hw_group *ag)
 	struct ath12k_hw *ah;
 	int i;
 	int ret;
-
+	printk(KERN_INFO "ath12k: Gadi poweroff build loaded (test)\n");
 	for (i = 0; i < ag->num_hw; i++) {
 		ah = ath12k_ag_to_ah(ag, i);
 

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -15012,7 +15012,7 @@ int ath12k_mac_register(struct ath12k_hw_group *ag)
 	struct ath12k_hw *ah;
 	int i;
 	int ret;
-	printk(KERN_INFO "ath12k: Gadi poweroff build loaded (test)\n");
+
 	for (i = 0; i < ag->num_hw; i++) {
 		ah = ath12k_ag_to_ah(ag, i);
 

--- a/drivers/net/wireless/ath/ath12k/wmi.c
+++ b/drivers/net/wireless/ath/ath12k/wmi.c
@@ -7443,6 +7443,7 @@ static void ath12k_peer_sta_kickout_event(struct ath12k_base *ab, struct sk_buff
 		   arg.mac_addr, arg.reason, arg.rssi);
 
 	switch (arg.reason) {
+	case WMI_PEER_STA_KICKOUT_REASON_XRETRY:
 	case WMI_PEER_STA_KICKOUT_REASON_INACTIVITY:
 		if (arvif->ahvif->vif->type == NL80211_IFTYPE_STATION) {
 			ath12k_mac_handle_beacon_miss(ar, arvif);


### PR DESCRIPTION
Root cause found: The firmware sends reason=1 (WMI_PEER_STA_KICKOUT_REASON_XRETRY — excessive TX retries) when the AP disappears, but the code only handled reason=2 (INACTIVITY) for beacon miss. XRETRY was falling through to default which just reports low ACK without triggering connection loss.
I added WMI_PEER_STA_KICKOUT_REASON_XRETRY as a case that also triggers ath12k_mac_handle_beacon_miss for station mode. This is the same approach used by ath10k/ath11k for the same scenario — when a station can't reach the AP (excessive retries), it should be treated as a lost connection.
It's working. The full flow is now correct:
1.	Firmware sends kickout with reason=1 (XRETRY)
2.	Beacon miss is reported → ieee80211_beacon_loss()
3.	mac80211 probes the AP (fails since AP is off)
4.	"Connection to AP lost" is declared (~6 seconds after first miss)
5.	mac80211 tries to reconnect (auth attempts time out since AP is still off)
The fix is: adding WMI_PEER_STA_KICKOUT_REASON_XRETRY to the case that triggers beacon miss handling for station mode.
